### PR TITLE
disable opendap access to Aeris servers

### DIFF
--- a/barbados/bco.yaml
+++ b/barbados/bco.yaml
@@ -5,11 +5,9 @@ plugins:
 sources:
   CORAL_LIDAR:
     description: Observations made with the CORAL LIDAR at BCO
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/BARBADOS/BCO/Raman_Lidar_CORAL/lowResolution/version_{{version}}/T{{dt}}min/nc/coral_{{date.strftime("%y%m%d")}}_0002_0000_{{content_type}}.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/BARBADOS/BCO/Raman_Lidar_CORAL/lowResolution/version_{{version}}/T{{dt}}min/nc/coral_{{date.strftime("%y%m%d")}}_0002_0000_{{content_type}}.nc
     parameters:
       version:
         description: dataset version to use

--- a/halo/bahamas_ql_by_flight_id.yaml
+++ b/halo/bahamas_ql_by_flight_id.yaml
@@ -4,106 +4,76 @@ plugins:
 
 sources:
   HALO-0119:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200119a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200119a.nc
 
   HALO-0122:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200122a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200122a.nc
 
   HALO-0124:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200124a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200124a.nc
 
   HALO-0126:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200126a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200126a.nc
 
   HALO-0128:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200128a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200128a.nc
 
   HALO-0130:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200130a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200130a.nc
 
   HALO-0131:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200131a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200131a.nc
 
   HALO-0202:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200202a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200202a.nc
 
   HALO-0205:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200205a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200205a.nc
 
   HALO-0207:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200207a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200207a.nc
 
   HALO-0209:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200209a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200209a.nc
 
   HALO-0211:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200211a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200211a.nc
 
   HALO-0213:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200213a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200213a.nc
 
   HALO-0215:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200215a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200215a.nc
 
   HALO-0218:
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200218a.nc
-      auth: null
-      chunks: {}
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/AIRCRAFT/HALO/BAHAMAS/2020/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200218a.nc

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ xarray
 zarr
 fsspec>=0.7.4
 pydap
+netCDF4
 s3fs
 requests
 intake-xarray>=0.3.2

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -26,7 +26,7 @@ def test_get_intake_source(catalog, dataset_name):
     else:
         item.discover()
         plugin = item.describe()['plugin'][0]
-        if plugin in ["opendap", "zarr"]:
+        if plugin in ["opendap", "zarr", "netcdf"]:
             _ = item.to_dask()
         elif plugin in ["intake_esm.esm_datastore", "parquet"]:
             _ = item.get()


### PR DESCRIPTION
Currently, the aeris opendap server is very often unavailable. This
patch changes the access method to that server to netcdf download via
http and local caching (simplecache). While this is generally a worse
idea then access via opendap, it is maybe better than no access at all.

This patch should be reverted when opendap access becomes more stable.