### PR TITLE
use yaml_file_cat as driver for nested catalogs

### DIFF
--- a/HALO/BAHAMAS.yaml
+++ b/HALO/BAHAMAS.yaml
@@ -7,5 +7,5 @@ sources:
     args:
       path: "{{CATALOG_DIR}}/BAHAMAS_QL.yaml"
     description: 'BAHAMAS QL data'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}

--- a/HALO/main.yaml
+++ b/HALO/main.yaml
@@ -3,19 +3,19 @@ sources:
     args:
       path: "{{CATALOG_DIR}}/BAHAMAS.yaml"
     description: 'Basic instrumentation data'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   specMACS:
     args:
       path: "{{CATALOG_DIR}}/specmacs/main.yaml"
     description: specMACS cloud imager data
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   UNIFIED:
     args:
       path: "{{CATALOG_DIR}}/unified.yaml"
     description: Heike Konows UNIFIED dataset
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}

--- a/HALO/specmacs/experimental.yaml
+++ b/HALO/specmacs/experimental.yaml
@@ -7,19 +7,19 @@ sources:
     args:
       path: "{{CATALOG_DIR}}/points.yaml"
     description: points on cloud surface located by stereo method
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   centroids:
     args:
       path: "{{CATALOG_DIR}}/centroids.yaml"
     description: reduced form of points
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   mesh:
     args:
       path: "{{CATALOG_DIR}}/mesh.yaml"
     description: cloud surfaces as determined by poisson reconstruction
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}

--- a/HALO/specmacs/main.yaml
+++ b/HALO/specmacs/main.yaml
@@ -7,12 +7,12 @@ sources:
     args:
       path: "{{CATALOG_DIR}}/cloudmaskSWIR.yaml"
     description: "specMACS cloudmask based on SWIR camera, see [description](https://macsserver.physik.uni-muenchen.de/campaigns/EUREC4A/products/cloudmask/)"
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   experimental:
     args:
       path: "{{CATALOG_DIR}}/experimental.yaml"
     description: centroids, point surface, and mesh for a case study for February 5
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}

--- a/HALO/unified.yaml
+++ b/HALO/unified.yaml
@@ -7,26 +7,26 @@ sources:
     args:
       path: "{{CATALOG_DIR}}/dropsondes_unified.yaml"
     description: dropsondes in HALO UNIFIED dataset.
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   HAMPradar:
     args:
       path: "{{CATALOG_DIR}}/radar_unified.yaml"
     description: radar data in HALO UNIFIED dataset.
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   HAMPradiometer:
     args:
       path: "{{CATALOG_DIR}}/radiometer_unified.yaml"
     description: radiometer data in HALO UNIFIED dataset.
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   BAHAMAS:
     args:
       path: "{{CATALOG_DIR}}/bahamas_unified.yaml"
     description: BAHAMAS data in HALO UNIFIED dataset.
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}

--- a/P3/isotope-analyzer.yaml
+++ b/P3/isotope-analyzer.yaml
@@ -3,12 +3,12 @@ sources:
     args:
       path: "{{CATALOG_DIR}}/isotope-analyzer-water-vapor-1hz.yaml"
     description: 'Isotope analyzer 1Hz humidity data'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   water_vapor_5hz:
     args:
       path: "{{CATALOG_DIR}}/isotope-analyzer-water-vapor-5hz.yaml"
     description: 'Isotope analyzer 5 Hzhumidity data'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}

--- a/P3/main.yaml
+++ b/P3/main.yaml
@@ -3,40 +3,40 @@ sources:
     args:
       path: "{{CATALOG_DIR}}/axbts.yaml"
     description: 'AXBT data'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   flight_level:
     args:
       path: "{{CATALOG_DIR}}/flight-level.yaml"
     description: 'Flight level data'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   isotope_analyzer:
     args:
       path: "{{CATALOG_DIR}}/isotope-analyzer.yaml"
     description: 'Isotope analyzer data'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   remote_sensing:
     args:
       path: "{{CATALOG_DIR}}/remote-sensing.yaml"
     description: 'W-band and SFMR data'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   w_band_radar:
     args:
       path: "{{CATALOG_DIR}}/w-band-radar.yaml"
     description: 'W-band radar data'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   wsra:
     args:
       path: "{{CATALOG_DIR}}/WSRA.yaml"
     description: 'Wide swath radar altimeter data'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}

--- a/barbados/main.yaml
+++ b/barbados/main.yaml
@@ -5,6 +5,6 @@ sources:
     description: Observations at BCO (Barbados Cloud Observatory)
     args:
       path: "{{CATALOG_DIR}}/bco.yaml"
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata:
       website: https://barbados.mpimet.mpg.de/

--- a/catalog.yml
+++ b/catalog.yml
@@ -11,40 +11,40 @@ sources:
     args:
       path: "{{CATALOG_DIR}}/radiosondes.yml"
     #description: 'EUREC4A Radiosondes Catalog'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   barbados:
     args:
       path: "{{CATALOG_DIR}}/barbados/main.yaml"
     description: 'Data from observations on Barbados'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   HALO:
     args:
       path: "{{CATALOG_DIR}}/HALO/main.yaml"
     description: 'Data from the HALO aircraft'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   P3:
     args:
       path: "{{CATALOG_DIR}}/P3/main.yaml"
     description: 'Data from the P3 aircraft'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   swifts:
     description: SWIFT ocean surface drifters
     args:
       path: "{{CATALOG_DIR}}/swifts.yml"
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}
 
   dropsondes:
     args:
       path: "{{CATALOG_DIR}}/dropsondes.yaml"
     description: 'Dropsonde dataset JOANNE.'
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}

--- a/dropsondes.yaml
+++ b/dropsondes.yaml
@@ -7,5 +7,5 @@ sources:
     args:
       path: "{{CATALOG_DIR}}/JOANNE/main.yaml"
     description: The EUREC4A dropsonde dataset JOANNE contains HALO and P3 dropsonde data.
-    driver: intake.catalog.local.YAMLFileCatalog
+    driver: yaml_file_cat
     metadata: {}


### PR DESCRIPTION
This is the official name from the [intake plugin directory](https://intake.readthedocs.io/en/latest/plugin-directory.html?highlight=yaml_file_cat#plugin-directory).
While it is also possible to directly specify python classes, this seems
to be odd for a general catalog. In particular, I could imagine that we
want to read intake catalogs from different programming languages at
some point in time and then hard coded python module names will not be
beneficial.