### PR TITLE
specMACS cloudmaskSWIR v2

### DIFF
--- a/HALO/specmacs/cloudmaskSWIR.yaml
+++ b/HALO/specmacs/cloudmaskSWIR.yaml
@@ -7,7 +7,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200119_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200119_v2.1.nc
       auth: null
       chunks: {}
 
@@ -15,7 +15,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200122_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200122_v2.1.nc
       auth: null
       chunks: {}
 
@@ -23,7 +23,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200124_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200124_v2.1.nc
       auth: null
       chunks: {}
 
@@ -31,7 +31,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200126_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200126_v2.1.nc
       auth: null
       chunks: {}
 
@@ -39,7 +39,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200128_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200128_v2.1.nc
       auth: null
       chunks: {}
 
@@ -47,7 +47,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200130_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200130_v2.1.nc
       auth: null
       chunks: {}
 
@@ -55,7 +55,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200131_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200131_v2.1.nc
       auth: null
       chunks: {}
 
@@ -63,7 +63,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200202_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200202_v2.1.nc
       auth: null
       chunks: {}
 
@@ -71,7 +71,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200205_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200205_v2.1.nc
       auth: null
       chunks: {}
 
@@ -79,7 +79,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200207_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200207_v2.1.nc
       auth: null
       chunks: {}
 
@@ -87,7 +87,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200209_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200209_v2.1.nc
       auth: null
       chunks: {}
 
@@ -95,7 +95,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200211_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200211_v2.1.nc
       auth: null
       chunks: {}
 
@@ -103,7 +103,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200213_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200213_v2.1.nc
       auth: null
       chunks: {}
 
@@ -111,7 +111,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200215_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200215_v2.1.nc
       auth: null
       chunks: {}
 
@@ -119,6 +119,6 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200218_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200218_v2.1.nc
       auth: null
       chunks: {}

--- a/HALO/specmacs/cloudmaskSWIR.yaml
+++ b/HALO/specmacs/cloudmaskSWIR.yaml
@@ -7,7 +7,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200119T092900-20200119T184859_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200119_v2.0.nc
       auth: null
       chunks: {}
 
@@ -15,7 +15,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200122T150000-20200122T215959_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200122_v2.0.nc
       auth: null
       chunks: {}
 
@@ -23,7 +23,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200124T101000-20200124T183959_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200124_v2.0.nc
       auth: null
       chunks: {}
 
@@ -31,7 +31,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200126T120530-20200126T212049_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200126_v2.0.nc
       auth: null
       chunks: {}
 
@@ -39,7 +39,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200128T150000-20200128T214959_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200128_v2.0.nc
       auth: null
       chunks: {}
 
@@ -47,7 +47,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200130T111500-20200130T150947_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200130_v2.0.nc
       auth: null
       chunks: {}
 
@@ -55,7 +55,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200131T150900-20200131T214959_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200131_v2.0.nc
       auth: null
       chunks: {}
 
@@ -63,7 +63,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS-SWIR_cloud_mask_20200202_v2.0.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200202_v2.0.nc
       auth: null
       chunks: {}
 
@@ -71,7 +71,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200205T100000-20200205T182359_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200205_v2.0.nc
       auth: null
       chunks: {}
 
@@ -79,7 +79,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200207T120200-20200207T211059_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200207_v2.0.nc
       auth: null
       chunks: {}
 
@@ -87,7 +87,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200209T101000-20200209T180459_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200209_v2.0.nc
       auth: null
       chunks: {}
 
@@ -95,7 +95,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200211T123000-20200211T212959_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200211_v2.0.nc
       auth: null
       chunks: {}
 
@@ -103,7 +103,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200213T100800-20200213T171659_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200213_v2.0.nc
       auth: null
       chunks: {}
 
@@ -111,7 +111,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200215T150800-20200215T215959_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200215_v2.0.nc
       auth: null
       chunks: {}
 
@@ -119,6 +119,6 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200218T101500-20200218T174459_v1.1.nc
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SPECMACS/ESSD_HALO_SPECMACS_CLOUDMASK/EUREC4A_HALO_specMACS-SWIR_cloudmask_20200218_v2.0.nc
       auth: null
       chunks: {}

--- a/HALO/specmacs/cloudmaskSWIR.yaml
+++ b/HALO/specmacs/cloudmaskSWIR.yaml
@@ -63,7 +63,7 @@ sources:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
     driver: opendap
     args:
-      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200202T112800-20200202T201459_v1.1.nc
+      urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS-SWIR_cloud_mask_20200202_v2.0.nc
       auth: null
       chunks: {}
 


### PR DESCRIPTION
This PR updates the specMACS cloudmaskSWIR to version 2. Currently there's only one file (for flight `HALO-0202`) available, thus the PR is started as a draft and will be updated as new files become available.