### PR TITLE
update swift entry to new file version `v2.1`

### DIFF
--- a/swifts.yml
+++ b/swifts.yml
@@ -8,39 +8,39 @@ sources:
     args:
       auth: null
       chunks: {}
-      urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT16_All_v1.1.nc
+      urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT16_All_v2.1.nc
 
   SWIFT17:
     driver: opendap
     args:
       auth: null
       chunks: {}
-      urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT17_All_v1.1.nc
+      urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT17_All_v2.1.nc
 
   SWIFT22:
     driver: opendap
     args:
       auth: null
       chunks: {}
-      urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT22_All_v1.1.nc
+      urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT22_All_v2.1.nc
 
   SWIFT23:
     driver: opendap
     args:
       auth: null
       chunks: {}
-      urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT23_All_v1.1.nc
+      urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT23_All_v2.1.nc
 
   SWIFT24:
     driver: opendap
     args:
       auth: null
       chunks: {}
-      urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT24_All_v1.1.nc
+      urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT24_All_v2.1.nc
 
   SWIFT25:
     driver: opendap
     args:
       auth: null
       chunks: {}
-      urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT25_All_v1.1.nc
+      urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT25_All_v2.1.nc


### PR DESCRIPTION
The swift files noted in the catalog are gone. Instead, there seem to be new files `v2.1` available on the [NOAA server](https://psl.noaa.gov/thredds/catalog/Datasets/ATOMIC/data/swift_drifters/catalog.html). I updated the intake catalog entry accordingly and hope that the tests run through again.