### PR TITLE
Kt19

### DIFF
--- a/HALO/kt19.yaml
+++ b/HALO/kt19.yaml
@@ -1,0 +1,7 @@
+sources:
+  cloudmask:
+    args:
+      path: "{{CATALOG_DIR}}/kt19_cloudmask.yaml"
+    description: 'KT-19 thermal radiometer cloud mask product'
+    driver: yaml_file_cat
+    metadata: {}

--- a/HALO/kt19_cloudmask.yaml
+++ b/HALO/kt19_cloudmask.yaml
@@ -1,0 +1,95 @@
+plugins:
+  source:
+    - module: intake_xarray
+sources:
+  HALO-0122:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_02_20200122/EUREC4A_HALO_KT19_cloudmask_20200122_v2.0.nc
+      auth: null
+      chunks: {}
+  HALO-0124:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_03_20200124/EUREC4A_HALO_KT19_cloudmask_20200124_v2.0.nc
+      auth: null
+      chunks: {}
+  HALO-0126:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_04_20200126/EUREC4A_HALO_KT19_cloudmask_20200126_v2.0.nc
+      auth: null
+      chunks: {}
+  HALO-0128:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_05_20200128/EUREC4A_HALO_KT19_cloudmask_20200128_v2.0.nc
+      auth: null
+      chunks: {}
+  HALO-0130:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_06_20200130/EUREC4A_HALO_KT19_cloudmask_20200130_v2.0.nc
+      auth: null
+      chunks: {}
+  HALO-0131:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_07_20200131/EUREC4A_HALO_KT19_cloudmask_20200131_v2.0.nc
+      auth: null
+      chunks: {}
+  HALO-0202:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_08_20200202/EUREC4A_HALO_KT19_cloudmask_20200202_v2.0.nc
+      auth: null
+      chunks: {}
+  HALO-0205:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_09_20200205/EUREC4A_HALO_KT19_cloudmask_20200205_v2.0.nc
+      auth: null
+      chunks: {}
+  HALO-0207:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_10_20200207/EUREC4A_HALO_KT19_cloudmask_20200207_v2.0.nc
+      auth: null
+      chunks: {}
+  HALO-0209:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_11_20200209/EUREC4A_HALO_KT19_cloudmask_20200209_v2.0.nc
+      auth: null
+      chunks: {}
+  HALO-0211:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_12_20200211/EUREC4A_HALO_KT19_cloudmask_20200211_v2.0.nc
+      auth: null
+      chunks: {}
+  HALO-0213:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_13_20200213/EUREC4A_HALO_KT19_cloudmask_20200213_v2.0.nc
+      auth: null
+      chunks: {}
+  HALO-0215:
+    description: KT-19 cloud mask.
+    driver: opendap
+    args:
+      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_14_20200215/EUREC4A_HALO_KT19_cloudmask_20200215_v2.0.nc
+      auth: null
+      chunks: {}

--- a/HALO/main.yaml
+++ b/HALO/main.yaml
@@ -34,6 +34,13 @@ sources:
     driver: yaml_file_cat
     metadata: {}
 
+  KT19:
+    args:
+      path: "{{CATALOG_DIR}}/kt19.yaml"
+    description: KT-19 thermal infrared radiometer data
+    driver: yaml_file_cat
+    metadata: {}
+
   WALES:
     args:
       path: "{{CATALOG_DIR}}/wales/main.yaml"


### PR DESCRIPTION
add KT-19 thermal infrared radiometer to the catalog. Currently, there are only cloud mask dataset available on AERIS. 