### PR TITLE
changed intake requirement to intake[dataframe]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # the most recent version of intake-xarray (v3.2.2) only supports the OPeNDAP
 # servers by URS and ESGF, the fork bellow allows for connecting to general OPeNDAP servers
-intake[dataframe]
+intake[dataframe] # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
 xarray
 zarr
 fsspec>=0.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # the most recent version of intake-xarray (v3.2.2) only supports the OPeNDAP
 # servers by URS and ESGF, the fork bellow allows for connecting to general OPeNDAP servers
-intake
+intake[dataframe]
 xarray
 zarr
 fsspec>=0.7.4


### PR DESCRIPTION
Since the newly released version of intake 0.6.1, `to_dask()` doesn't
work anymore without this install secion. This is most likely the
current primary reason for #45 to fail.