### PR TITLE
Excluding further incompatible netcdf4 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ xarray
 zarr
 fsspec>=0.7.4
 pydap
-netcdf4!=1.5.4,!=1.5.5,!=1.5.5.1 # this is due to https://github.com/Unidata/netcdf4-python/issues/1052
+netcdf4!=1.5.4,!=1.5.5,!=1.5.5.1,!=1.5.1.2 # this is due to https://github.com/Unidata/netcdf4-python/issues/1052
 s3fs
 ipfsspec
 requests


### PR DESCRIPTION
netCDF4 version 1.5.1.2 causes issues
e.g.
```python
import xarray as xr
xr.open_dataset("https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/RADIATIVE-PROFILES/rad_profiles.nc")

KeyError: [<class 'netCDF4._netCDF4.Dataset'>, ('https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/RADIATIVE-PROFILES/rad_profiles.nc',), 'r', (('clobber', True), ('diskless', False), ('format', 'NETCDF4'), ('persist', False))]
```