### PR TITLE
OPeNDAP: change chunk from {} to null

### DIFF
--- a/ATR/main.yaml
+++ b/ATR/main.yaml
@@ -9,7 +9,7 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_ATR_v1.0.nc
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
     metadata:
       tags:

--- a/Atalante/main.yaml
+++ b/Atalante/main.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_Atalante_v1.0.nc
     description: Atalante track

--- a/BOREAL/main.yaml
+++ b/BOREAL/main.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_BOREAL_v1.0.nc
     description: BOREAL track

--- a/CU-RAAVEN/main.yaml
+++ b/CU-RAAVEN/main.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_CU-RAAVEN_v1.0.nc
     description: CU-RAAVEN track

--- a/Caravela/main.yaml
+++ b/Caravela/main.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_Caravela_v1.0.nc
     description: Caravela track

--- a/HALO/BAHAMAS_PositionAttitude.yaml
+++ b/HALO/BAHAMAS_PositionAttitude.yaml
@@ -8,116 +8,116 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200115_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0118:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200118_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0119:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200119_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0122:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200122_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0124:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200124_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0126:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200126_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0128:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200128_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0130:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200130_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0131:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200131_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0202:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200202_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0205:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200205_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0207:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200207_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0209:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200209_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0211:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200211_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0213:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200213_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0215:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200215_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0218:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200218_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/BAHAMAS_QL.yaml
+++ b/HALO/BAHAMAS_QL.yaml
@@ -8,102 +8,102 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200119a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0122:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200122a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0124:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200124a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0126:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200126a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0128:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200128a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0130:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200130a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0131:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200131a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0202:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200202a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0205:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200205a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0207:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200207a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0209:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200209a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0211:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200211a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0213:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200213a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0215:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200215a.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0218:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200218a.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/bacardi_irradiances.yaml
+++ b/HALO/bacardi_irradiances.yaml
@@ -9,102 +9,102 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200119/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200119_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0122:
     description: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200122/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200122_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     escription: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200124/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200124_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     escription: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200126/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200126_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200128/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200128_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     escription: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200130/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200130_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     escription: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200131/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200131_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     escription: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200202/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200202_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     escription: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200205/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200205_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     escription: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200207/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200207_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     escription: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200209/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200209_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200211/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200211_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     escription: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200213/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200213_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     escription: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200215/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200215_R1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0218:
     escription: BACARDI irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200218/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200218_R1.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/kt19_cloudmask.yaml
+++ b/HALO/kt19_cloudmask.yaml
@@ -8,88 +8,88 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_02_20200122/EUREC4A_HALO_KT19_cloudmask_20200122_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: KT-19 cloud mask.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_03_20200124/EUREC4A_HALO_KT19_cloudmask_20200124_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: KT-19 cloud mask.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_04_20200126/EUREC4A_HALO_KT19_cloudmask_20200126_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: KT-19 cloud mask.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_05_20200128/EUREC4A_HALO_KT19_cloudmask_20200128_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: KT-19 cloud mask.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_06_20200130/EUREC4A_HALO_KT19_cloudmask_20200130_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: KT-19 cloud mask.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_07_20200131/EUREC4A_HALO_KT19_cloudmask_20200131_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: KT-19 cloud mask.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_08_20200202/EUREC4A_HALO_KT19_cloudmask_20200202_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: KT-19 cloud mask.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_09_20200205/EUREC4A_HALO_KT19_cloudmask_20200205_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: KT-19 cloud mask.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_10_20200207/EUREC4A_HALO_KT19_cloudmask_20200207_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: KT-19 cloud mask.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_11_20200209/EUREC4A_HALO_KT19_cloudmask_20200209_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: KT-19 cloud mask.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_12_20200211/EUREC4A_HALO_KT19_cloudmask_20200211_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: KT-19 cloud mask.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_13_20200213/EUREC4A_HALO_KT19_cloudmask_20200213_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: KT-19 cloud mask.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/KT-19/RF_14_20200215/EUREC4A_HALO_KT19_cloudmask_20200215_v4.0.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/main.yaml
+++ b/HALO/main.yaml
@@ -63,7 +63,7 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_HALO_v1.0.nc
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
     driver: opendap
     description: HALO track

--- a/HALO/smart_irradiances.yaml
+++ b/HALO/smart_irradiances.yaml
@@ -9,88 +9,88 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF02_20200122/EUREC4A_HALO_SMART_spectral_irradiances_20200122_R3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: SMART spectral irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF03_20200124/EUREC4A_HALO_SMART_spectral_irradiances_20200124_R3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: SMART spectral irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF04_20200126/EUREC4A_HALO_SMART_spectral_irradiances_20200126_R3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: SMART spectral irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF05_20200128/EUREC4A_HALO_SMART_spectral_irradiances_20200128_R3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: SMART spectral irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF06_20200130/EUREC4A_HALO_SMART_spectral_irradiances_20200130_R3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: SMART spectral irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF07_20200131/EUREC4A_HALO_SMART_spectral_irradiances_20200131_R3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: SMART spectral irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF08_20200202/EUREC4A_HALO_SMART_spectral_irradiances_20200202_R3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: SMART spectral irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF09_20200205/EUREC4A_HALO_SMART_spectral_irradiances_20200205_R3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: SMART spectral irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF10_20200207/EUREC4A_HALO_SMART_spectral_irradiances_20200207_R3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: SMART spectral irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF11_20200209/EUREC4A_HALO_SMART_spectral_irradiances_20200209_R3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: SMART spectral irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF12_20200211/EUREC4A_HALO_SMART_spectral_irradiances_20200211_R3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: SMART spectral irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF13_20200213/EUREC4A_HALO_SMART_spectral_irradiances_20200213_R3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: SMART spectral irradiances.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF14_20200215/EUREC4A_HALO_SMART_spectral_irradiances_20200215_R3.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/specmacs/centroids.yaml
+++ b/HALO/specmacs/centroids.yaml
@@ -9,25 +9,25 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/centroids_HALO-0205_sl1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205_sl2:
     description: reduced form of points
     driver: opendap
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/centroids_HALO-0205_sl2.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205_sl3:
     description: reduced form of points
     driver: opendap
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/centroids_HALO-0205_sl3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205_sl4:
     description: reduced form of points
     driver: opendap
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/centroids_HALO-0205_sl4.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/specmacs/cloudmaskSWIR.yaml
+++ b/HALO/specmacs/cloudmaskSWIR.yaml
@@ -9,7 +9,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200119T092900-20200119T184859_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0122:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -17,7 +17,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200122T150000-20200122T215959_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0124:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -25,7 +25,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200124T101000-20200124T183959_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0126:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -33,7 +33,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200126T120530-20200126T212049_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0128:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -41,7 +41,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200128T150000-20200128T214959_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0130:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -49,7 +49,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200130T111500-20200130T150947_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0131:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -57,7 +57,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200131T150900-20200131T214959_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0202:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -65,7 +65,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200202T112800-20200202T201459_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0205:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -73,7 +73,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200205T100000-20200205T182359_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0207:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -81,7 +81,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200207T120200-20200207T211059_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0209:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -89,7 +89,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200209T101000-20200209T180459_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0211:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -97,7 +97,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200211T123000-20200211T212959_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0213:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -105,7 +105,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200213T100800-20200213T171659_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0215:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -113,7 +113,7 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200215T150800-20200215T215959_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
 
   HALO-0218:
     description: The cloud mask was derived from radiance measurements of the SWIR camera of the specMACS instrument.
@@ -121,4 +121,4 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloudmask/EUREC4A_HALO_specMACS_cloud_mask_20200218T101500-20200218T174459_v1.1.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/specmacs/mesh.yaml
+++ b/HALO/specmacs/mesh.yaml
@@ -9,25 +9,25 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/mesh_HALO-0205_sl1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205_sl2:
     description: cloud surfaces as determined by poisson reconstruction
     driver: opendap
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/mesh_HALO-0205_sl2.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205_sl3:
     description: cloud surfaces as determined by poisson reconstruction
     driver: opendap
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/mesh_HALO-0205_sl3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205_sl4:
     description: cloud surfaces as determined by poisson reconstruction
     driver: opendap
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/mesh_HALO-0205_sl4.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/specmacs/points.yaml
+++ b/HALO/specmacs/points.yaml
@@ -9,25 +9,25 @@ sources:
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/points_HALO-0205_sl1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205_sl2:
     description: points on cloud surface located by stereo method
     driver: opendap
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/points_HALO-0205_sl2.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205_sl3:
     description: points on cloud surface located by stereo method
     driver: opendap
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/points_HALO-0205_sl3.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205_sl4:
     description: points on cloud surface located by stereo method
     driver: opendap
     args:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/points_HALO-0205_sl4.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/unified/MWR_cloud_mask_unified.yaml
+++ b/HALO/unified/MWR_cloud_mask_unified.yaml
@@ -8,102 +8,102 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200119_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0122:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200122_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200124_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200126_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200128_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200130_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200131_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200202_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200205_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200207_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200209_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200211_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200213_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200215_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0218:
     description: HAMP Microwave Radiometer Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-MWR_cloud_mask_20200218_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/unified/MWR_retrievals_unified.yaml
+++ b/HALO/unified/MWR_retrievals_unified.yaml
@@ -8,102 +8,102 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200119093425.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0122:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200122145736.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200124092931.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200126120530.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200128145834.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200130111934.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200131150836.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200202112802.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200205091552.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200207120224.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200209091432.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200211122905.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200213075611.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200215150731.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0218:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.8/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.8_20200218101105.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/unified/Radar_cloud_mask_unified.yaml
+++ b/HALO/unified/Radar_cloud_mask_unified.yaml
@@ -8,102 +8,102 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200119_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0122:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200122_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200124_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200126_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200128_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200130_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200131_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200202_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200205_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200207_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200209_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200211_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200213_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200215_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0218:
     description: HAMP Cloud Radar Cloud Mask with unified time coordinate.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/cloudmask_v0.9/EUREC4A_HALO_HAMP-Radar_cloud_mask_20200218_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/unified/bahamas_unified.yaml
+++ b/HALO/unified/bahamas_unified.yaml
@@ -8,102 +8,102 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200119_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0122:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200122_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200124_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200126_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200128_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200130_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200131_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200202_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200205_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200207_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200209_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200211_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200213_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200215_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0218:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200218_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/unified/dropsondes_unified.yaml
+++ b/HALO/unified/dropsondes_unified.yaml
@@ -8,102 +8,102 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200119_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0122:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200122_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200124_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200126_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200128_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200130_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200131_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200202_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200205_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200207_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200209_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200211_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200213_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200215_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0218:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200218_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/unified/radar_unified.yaml
+++ b/HALO/unified/radar_unified.yaml
@@ -8,102 +8,102 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200119_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0122:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200122_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200124_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200126_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200128_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200130_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200131_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200202_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200205_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200207_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200209_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200211_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200213_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200215_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0218:
     description: radar data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200218_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/unified/radiometer_unified.yaml
+++ b/HALO/unified/radiometer_unified.yaml
@@ -8,102 +8,102 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200119_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0122:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200122_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200124_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200126_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200128_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200130_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200131_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200202_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200205_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200207_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200209_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200211_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200213_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200215_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0218:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200218_v0.9.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/velox_cloudmask.yaml
+++ b/HALO/velox_cloudmask.yaml
@@ -9,81 +9,81 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/VELOX/RF_03_20200124/EUREC4A_HALO_VELOX_cloudmask_20200124_v3.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: VELOX cloud mask 
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/VELOX/RF_04_20200126/EUREC4A_HALO_VELOX_cloudmask_20200126_v3.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: VELOX cloud mask 
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/VELOX/RF_05_20200128/EUREC4A_HALO_VELOX_cloudmask_20200128_v3.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: VELOX cloud mask 
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/VELOX/RF_06_20200130/EUREC4A_HALO_VELOX_cloudmask_20200130_v3.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: VELOX cloud mask 
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/VELOX/RF_07_20200131/EUREC4A_HALO_VELOX_cloudmask_20200131_v3.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: VELOX cloud mask 
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/VELOX/RF_08_20200202/EUREC4A_HALO_VELOX_cloudmask_20200202_v3.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: VELOX cloud mask 
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/VELOX/RF_09_20200205/EUREC4A_HALO_VELOX_cloudmask_20200205_v3.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: VELOX cloud mask 
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/VELOX/RF_10_20200207/EUREC4A_HALO_VELOX_cloudmask_20200207_v3.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: VELOX cloud mask 
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/VELOX/RF_11_20200209/EUREC4A_HALO_VELOX_cloudmask_20200209_v3.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: VELOX cloud mask 
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/VELOX/RF_12_20200211/EUREC4A_HALO_VELOX_cloudmask_20200211_v3.0.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: VELOX cloud mask 
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/VELOX/RF_13_20200213/EUREC4A_HALO_VELOX_cloudmask_20200213_v3.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: VELOX cloud mask 
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/VELOX/RF_14_20200215/EUREC4A_HALO_VELOX_cloudmask_20200215_v3.0.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/wales/wales_adepg.yaml
+++ b/HALO/wales/wales_adepg.yaml
@@ -8,88 +8,88 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_22/EUREC4A_HALO_WALES_adepg_20200122a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_24/EUREC4A_HALO_WALES_adepg_20200124a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_26/EUREC4A_HALO_WALES_adepg_20200126a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_28/EUREC4A_HALO_WALES_adepg_20200128a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_30/EUREC4A_HALO_WALES_adepg_20200130a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_31/EUREC4A_HALO_WALES_adepg_20200131a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_02/EUREC4A_HALO_WALES_adepg_20200202a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_05/EUREC4A_HALO_WALES_adepg_20200205a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_07/EUREC4A_HALO_WALES_adepg_20200207a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_09/EUREC4A_HALO_WALES_adepg_20200209a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_11/EUREC4A_HALO_WALES_adepg_20200211a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_13/EUREC4A_HALO_WALES_adepg_20200213a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_15/EUREC4A_HALO_WALES_adepg_20200215a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/wales/wales_bsrg.yaml
+++ b/HALO/wales/wales_bsrg.yaml
@@ -8,88 +8,88 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_22/EUREC4A_HALO_WALES_bsrg_20200122a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_24/EUREC4A_HALO_WALES_bsrg_20200124a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_26/EUREC4A_HALO_WALES_bsrg_20200126a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_28/EUREC4A_HALO_WALES_bsrg_20200128a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_30/EUREC4A_HALO_WALES_bsrg_20200130a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_31/EUREC4A_HALO_WALES_bsrg_20200131a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_02/EUREC4A_HALO_WALES_bsrg_20200202a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_05/EUREC4A_HALO_WALES_bsrg_20200205a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_07/EUREC4A_HALO_WALES_bsrg_20200207a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_09/EUREC4A_HALO_WALES_bsrg_20200209a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_11/EUREC4A_HALO_WALES_bsrg_20200211a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_13/EUREC4A_HALO_WALES_bsrg_20200213a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_15/EUREC4A_HALO_WALES_bsrg_20200215a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/wales/wales_bsri.yaml
+++ b/HALO/wales/wales_bsri.yaml
@@ -8,88 +8,88 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_22/EUREC4A_HALO_WALES_bsri_20200122a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_24/EUREC4A_HALO_WALES_bsri_20200124a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_26/EUREC4A_HALO_WALES_bsri_20200126a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_28/EUREC4A_HALO_WALES_bsri_20200128a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_30/EUREC4A_HALO_WALES_bsri_20200130a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_31/EUREC4A_HALO_WALES_bsri_20200131a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_02/EUREC4A_HALO_WALES_bsri_20200202a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_05/EUREC4A_HALO_WALES_bsri_20200205a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_07/EUREC4A_HALO_WALES_bsri_20200207a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_09/EUREC4A_HALO_WALES_bsri_20200209a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_11/EUREC4A_HALO_WALES_bsri_20200211a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_13/EUREC4A_HALO_WALES_bsri_20200213a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_15/EUREC4A_HALO_WALES_bsri_20200215a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/wales/wales_cloudtop.yaml
+++ b/HALO/wales/wales_cloudtop.yaml
@@ -8,88 +8,88 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_22/EUREC4A_HALO_WALES_cloudtop_20200122_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: WALES-Lidar cloud top height, cloud optical thickness and cloud flag data.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_24/EUREC4A_HALO_WALES_cloudtop_20200124_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: WALES-Lidar cloud top height, cloud optical thickness and cloud flag data.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_26/EUREC4A_HALO_WALES_cloudtop_20200126_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: WALES-Lidar cloud top height, cloud optical thickness and cloud flag data.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_28/EUREC4A_HALO_WALES_cloudtop_20200128_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: WALES-Lidar cloud top height, cloud optical thickness and cloud flag data.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_30/EUREC4A_HALO_WALES_cloudtop_20200130_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: WALES-Lidar cloud top height, cloud optical thickness and cloud flag data.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_31/EUREC4A_HALO_WALES_cloudtop_20200131_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: WALES-Lidar cloud top height, cloud optical thickness and cloud flag data.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_02/EUREC4A_HALO_WALES_cloudtop_20200202_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: WALES-Lidar cloud top height, cloud optical thickness and cloud flag data.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_05/EUREC4A_HALO_WALES_cloudtop_20200205_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: WALES-Lidar cloud top height, cloud optical thickness and cloud flag data.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_07/EUREC4A_HALO_WALES_cloudtop_20200207_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: WALES-Lidar cloud top height, cloud optical thickness and cloud flag data.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_09/EUREC4A_HALO_WALES_cloudtop_20200209_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: WALES-Lidar cloud top height, cloud optical thickness and cloud flag data.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_11/EUREC4A_HALO_WALES_cloudtop_20200211_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: WALES-Lidar cloud top height, cloud optical thickness and cloud flag data.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_13/EUREC4A_HALO_WALES_cloudtop_20200213_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: WALES-Lidar cloud top height, cloud optical thickness and cloud flag data.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_15/EUREC4A_HALO_WALES_cloudtop_20200215_V1.1.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/HALO/wales/wales_wv.yaml
+++ b/HALO/wales/wales_wv.yaml
@@ -8,88 +8,88 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_22/EUREC4A_HALO_WALES_wv_20200122a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0124:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_24/EUREC4A_HALO_WALES_wv_20200124a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0126:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_26/EUREC4A_HALO_WALES_wv_20200126a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0128:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_28/EUREC4A_HALO_WALES_wv_20200128a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0130:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_30/EUREC4A_HALO_WALES_wv_20200130a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0131:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_31/EUREC4A_HALO_WALES_wv_20200131a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0202:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_02/EUREC4A_HALO_WALES_wv_20200202a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0205:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_05/EUREC4A_HALO_WALES_wv_20200205a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0207:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_07/EUREC4A_HALO_WALES_wv_20200207a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0209:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_09/EUREC4A_HALO_WALES_wv_20200209a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0211:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_11/EUREC4A_HALO_WALES_wv_20200211a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0213:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_13/EUREC4A_HALO_WALES_wv_20200213a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null
   HALO-0215:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_15/EUREC4A_HALO_WALES_wv_20200215a_V1.nc
       auth: null
-      chunks: {}
+      chunks: null

--- a/Humpback/main.yaml
+++ b/Humpback/main.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_Humpback_v1.0.nc
     description: Humpback track

--- a/IFM/IFM03.yaml
+++ b/IFM/IFM03.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_IFM03_v1.0.nc
     description: IFM03 track

--- a/IFM/IFM09.yaml
+++ b/IFM/IFM09.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_IFM09_v1.0.nc
     description: IFM09 track

--- a/IFM/IFM12.yaml
+++ b/IFM/IFM12.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_IFM12_v1.0.nc
     description: IFM12 track

--- a/Kracken/main.yaml
+++ b/Kracken/main.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_Kracken_v1.0.nc
     description: Kracken track

--- a/MPCK/MPCK-plus.yaml
+++ b/MPCK/MPCK-plus.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_MPCK-plus_v1.0.nc
     description: MPCK-plus track

--- a/MPCK/mini-MPCK.yaml
+++ b/MPCK/mini-MPCK.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_mini-MPCK_v1.0.nc
     description: mini-MPCK track

--- a/MS-Merian/main.yaml
+++ b/MS-Merian/main.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_MS-Merian_v1.0.nc
     description: MS-Merian track

--- a/Melonhead/main.yaml
+++ b/Melonhead/main.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_Melonhead_v1.0.nc
     description: Melonhead track

--- a/Omura/main.yaml
+++ b/Omura/main.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_Omura_v1.0.nc
     description: Omura track

--- a/P3/WSRA.yaml
+++ b/P3/WSRA.yaml
@@ -7,7 +7,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220627/EUREC4A_ATOMIC_P3_WSRA_20200117_v1.0.nc
 
@@ -15,7 +15,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220627/EUREC4A_ATOMIC_P3_WSRA_20200119_v1.0.nc
 
@@ -23,7 +23,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220627/EUREC4A_ATOMIC_P3_WSRA_20200123_v1.0.nc
 
@@ -31,7 +31,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220627/EUREC4A_ATOMIC_P3_WSRA_20200124_v1.0.nc
 
@@ -39,7 +39,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220627/EUREC4A_ATOMIC_P3_WSRA_20200131_v1.0.nc
 
@@ -47,7 +47,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220627/EUREC4A_ATOMIC_P3_WSRA_20200203_v1.0.nc
 
@@ -55,7 +55,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220627/EUREC4A_ATOMIC_P3_WSRA_20200204_v1.0.nc
 
@@ -63,7 +63,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220627/EUREC4A_ATOMIC_P3_WSRA_20200205_v1.0.nc
 
@@ -71,7 +71,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220627/EUREC4A_ATOMIC_P3_WSRA_20200209_v1.0.nc
 
@@ -79,7 +79,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220627/EUREC4A_ATOMIC_P3_WSRA_20200210_v1.0.nc
 
@@ -87,6 +87,6 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220627/EUREC4A_ATOMIC_P3_WSRA_20200211_v1.0.nc

--- a/P3/axbts.yaml
+++ b/P3/axbts.yaml
@@ -7,6 +7,6 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220436/EUREC4A_ATOMIC_P3_AXBT_v1.0.nc

--- a/P3/flight-level.yaml
+++ b/P3/flight-level.yaml
@@ -7,7 +7,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220621/EUREC4A_ATOMIC_P3_Flight-level_20200117_v1.0.nc
 
@@ -15,7 +15,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220621/EUREC4A_ATOMIC_P3_Flight-level_20200119_v1.0.nc
 
@@ -23,7 +23,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220621/EUREC4A_ATOMIC_P3_Flight-level_20200123_v1.0.nc
 
@@ -31,7 +31,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220621/EUREC4A_ATOMIC_P3_Flight-level_20200124_v1.0.nc
 
@@ -39,7 +39,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220621/EUREC4A_ATOMIC_P3_Flight-level_20200131_v1.0.nc
 
@@ -47,7 +47,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220621/EUREC4A_ATOMIC_P3_Flight-level_20200203_v1.0.nc
 
@@ -55,7 +55,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220621/EUREC4A_ATOMIC_P3_Flight-level_20200204_v1.0.nc
 
@@ -63,7 +63,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220621/EUREC4A_ATOMIC_P3_Flight-level_20200205_v1.0.nc
 
@@ -71,7 +71,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220621/EUREC4A_ATOMIC_P3_Flight-level_20200209_v1.0.nc
 
@@ -79,7 +79,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220621/EUREC4A_ATOMIC_P3_Flight-level_20200210_v1.0.nc
 
@@ -87,6 +87,6 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220621/EUREC4A_ATOMIC_P3_Flight-level_20200211_v1.0.nc

--- a/P3/isotope-analyzer-water-vapor-1hz.yaml
+++ b/P3/isotope-analyzer-water-vapor-1hz.yaml
@@ -7,7 +7,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-1Hz_20200117_v1.0.nc
 
@@ -15,7 +15,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-1Hz_20200119_v1.0.nc
 
@@ -23,7 +23,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-1Hz_20200123_v1.0.nc
 
@@ -31,7 +31,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-1Hz_20200124_v1.0.nc
 
@@ -39,7 +39,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-1Hz_20200131_v1.0.nc
 
@@ -47,7 +47,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-1Hz_20200203_v1.0.nc
 
@@ -55,7 +55,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-1Hz_20200204_v1.0.nc
 
@@ -63,7 +63,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-1Hz_20200205_v1.0.nc
 
@@ -71,7 +71,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-1Hz_20200209_v1.0.nc
 
@@ -79,7 +79,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-1Hz_20200210_v1.0.nc
 
@@ -87,6 +87,6 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-1Hz_20200211_v1.0.nc

--- a/P3/isotope-analyzer-water-vapor-5hz.yaml
+++ b/P3/isotope-analyzer-water-vapor-5hz.yaml
@@ -7,7 +7,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-5Hz_20200117_v1.0.nc
 
@@ -15,7 +15,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-5Hz_20200119_v1.0.nc
 
@@ -23,7 +23,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-5Hz_20200123_v1.0.nc
 
@@ -31,7 +31,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-5Hz_20200124_v1.0.nc
 
@@ -39,7 +39,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-5Hz_20200131_v1.0.nc
 
@@ -47,7 +47,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-5Hz_20200203_v1.0.nc
 
@@ -55,7 +55,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-5Hz_20200204_v1.0.nc
 
@@ -63,7 +63,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-5Hz_20200205_v1.0.nc
 
@@ -71,7 +71,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-5Hz_20200209_v1.0.nc
 
@@ -79,7 +79,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-5Hz_20200210_v1.0.nc
 
@@ -87,6 +87,6 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220631/EUREC4A_ATOMIC_P3_Isotope-Analyzer_Water-Vapor-5Hz_20200211_v1.0.nc

--- a/P3/remote-sensing.yaml
+++ b/P3/remote-sensing.yaml
@@ -7,7 +7,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220625/EUREC4A_ATOMIC_P3_Remote-sensing_20200117_v1.0.nc
 
@@ -15,7 +15,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220625/EUREC4A_ATOMIC_P3_Remote-sensing_20200119_v1.0.nc
 
@@ -23,7 +23,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220625/EUREC4A_ATOMIC_P3_Remote-sensing_20200123_v1.0.nc
 
@@ -31,7 +31,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220625/EUREC4A_ATOMIC_P3_Remote-sensing_20200124_v1.0.nc
 
@@ -39,7 +39,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220625/EUREC4A_ATOMIC_P3_Remote-sensing_20200131_v1.0.nc
 
@@ -47,7 +47,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220625/EUREC4A_ATOMIC_P3_Remote-sensing_20200203_v1.0.nc
 
@@ -55,7 +55,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220625/EUREC4A_ATOMIC_P3_Remote-sensing_20200204_v1.0.nc
 
@@ -63,7 +63,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220625/EUREC4A_ATOMIC_P3_Remote-sensing_20200205_v1.0.nc
 
@@ -71,7 +71,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220625/EUREC4A_ATOMIC_P3_Remote-sensing_20200209_v1.0.nc
 
@@ -79,7 +79,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220625/EUREC4A_ATOMIC_P3_Remote-sensing_20200210_v1.0.nc
 
@@ -87,6 +87,6 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220625/EUREC4A_ATOMIC_P3_Remote-sensing_20200211_v1.0.nc

--- a/P3/w-band-radar.yaml
+++ b/P3/w-band-radar.yaml
@@ -7,7 +7,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220624/EUREC4A_ATOMIC_P3_W-band-radar_20200117_v1.0.nc
 
@@ -15,7 +15,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220624/EUREC4A_ATOMIC_P3_W-band-radar_20200119_v1.0.nc
 
@@ -23,7 +23,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220624/EUREC4A_ATOMIC_P3_W-band-radar_20200123_v1.0.nc
 
@@ -31,7 +31,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220624/EUREC4A_ATOMIC_P3_W-band-radar_20200124_v1.0.nc
 
@@ -39,7 +39,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220624/EUREC4A_ATOMIC_P3_W-band-radar_20200131_v1.0.nc
 
@@ -47,7 +47,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220624/EUREC4A_ATOMIC_P3_W-band-radar_20200203_v1.0.nc
 
@@ -55,7 +55,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220624/EUREC4A_ATOMIC_P3_W-band-radar_20200204_v1.0.nc
 
@@ -63,7 +63,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220624/EUREC4A_ATOMIC_P3_W-band-radar_20200205_v1.0.nc
 
@@ -71,7 +71,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220624/EUREC4A_ATOMIC_P3_W-band-radar_20200209_v1.0.nc
 
@@ -79,7 +79,7 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220624/EUREC4A_ATOMIC_P3_W-band-radar_20200210_v1.0.nc
 
@@ -87,6 +87,6 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/ncei/archive/data/0220624/EUREC4A_ATOMIC_P3_W-band-radar_20200211_v1.0.nc

--- a/QuadCopter/main.yaml
+++ b/QuadCopter/main.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_QuadCopter_v1.0.nc
     description: QuadCopter track

--- a/RonBrown/main.yaml
+++ b/RonBrown/main.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_RonBrown_v1.0.nc
     description: RonBrown track

--- a/SD/SD-1026.yaml
+++ b/SD/SD-1026.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SD-1026_v1.0.nc
     description: SD-1026 track

--- a/SD/SD-1060.yaml
+++ b/SD/SD-1060.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SD-1060_v1.0.nc
     description: SD-1060 track

--- a/SD/SD-1061.yaml
+++ b/SD/SD-1061.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SD-1061_v1.0.nc
     description: SD-1061 track

--- a/SD/SD-1063.yaml
+++ b/SD/SD-1063.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SD-1063_v1.0.nc
     description: SD-1063 track

--- a/SD/SD-1064.yaml
+++ b/SD/SD-1064.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SD-1064_v1.0.nc
     description: SD-1064 track

--- a/SVP/SVP-B-4101696.yaml
+++ b/SVP/SVP-B-4101696.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-B-4101696_v1.0.nc
     description: SVP-B-4101696 track

--- a/SVP/SVP-B-4101697.yaml
+++ b/SVP/SVP-B-4101697.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-B-4101697_v1.0.nc
     description: SVP-B-4101697 track

--- a/SVP/SVP-B-4101698.yaml
+++ b/SVP/SVP-B-4101698.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-B-4101698_v1.0.nc
     description: SVP-B-4101698 track

--- a/SVP/SVP-B-4101699.yaml
+++ b/SVP/SVP-B-4101699.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-B-4101699_v1.0.nc
     description: SVP-B-4101699 track

--- a/SVP/SVP-B-4101780.yaml
+++ b/SVP/SVP-B-4101780.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-B-4101780_v1.0.nc
     description: SVP-B-4101780 track

--- a/SVP/SVP-BRST-4402505.yaml
+++ b/SVP/SVP-BRST-4402505.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BRST-4402505_v1.0.nc
     description: SVP-BRST-4402505 track

--- a/SVP/SVP-BRST-4402506.yaml
+++ b/SVP/SVP-BRST-4402506.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BRST-4402506_v1.0.nc
     description: SVP-BRST-4402506 track

--- a/SVP/SVP-BRST-4402507.yaml
+++ b/SVP/SVP-BRST-4402507.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BRST-4402507_v1.0.nc
     description: SVP-BRST-4402507 track

--- a/SVP/SVP-BRST-4402508.yaml
+++ b/SVP/SVP-BRST-4402508.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BRST-4402508_v1.0.nc
     description: SVP-BRST-4402508 track

--- a/SVP/SVP-BRST-6203717.yaml
+++ b/SVP/SVP-BRST-6203717.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BRST-6203717_v1.0.nc
     description: SVP-BRST-6203717 track

--- a/SVP/SVP-BS-4101757.yaml
+++ b/SVP/SVP-BS-4101757.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BS-4101757_v1.0.nc
     description: SVP-BS-4101757 track

--- a/SVP/SVP-BS-4101758.yaml
+++ b/SVP/SVP-BS-4101758.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BS-4101758_v1.0.nc
     description: SVP-BS-4101758 track

--- a/SVP/SVP-BSW-3101569.yaml
+++ b/SVP/SVP-BSW-3101569.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BSW-3101569_v1.0.nc
     description: SVP-BSW-3101569 track

--- a/SVP/SVP-BSW-3101570.yaml
+++ b/SVP/SVP-BSW-3101570.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BSW-3101570_v1.0.nc
     description: SVP-BSW-3101570 track

--- a/SVP/SVP-BSW-3101571.yaml
+++ b/SVP/SVP-BSW-3101571.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BSW-3101571_v1.0.nc
     description: SVP-BSW-3101571 track

--- a/SVP/SVP-BSW-3101572.yaml
+++ b/SVP/SVP-BSW-3101572.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BSW-3101572_v1.0.nc
     description: SVP-BSW-3101572 track

--- a/SVP/SVP-BSW-3101573.yaml
+++ b/SVP/SVP-BSW-3101573.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BSW-3101573_v1.0.nc
     description: SVP-BSW-3101573 track

--- a/SVP/SVP-BSW-3101574.yaml
+++ b/SVP/SVP-BSW-3101574.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BSW-3101574_v1.0.nc
     description: SVP-BSW-3101574 track

--- a/SVP/SVP-BSW-3101575.yaml
+++ b/SVP/SVP-BSW-3101575.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BSW-3101575_v1.0.nc
     description: SVP-BSW-3101575 track

--- a/SVP/SVP-BSW-3101576.yaml
+++ b/SVP/SVP-BSW-3101576.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BSW-3101576_v1.0.nc
     description: SVP-BSW-3101576 track

--- a/SVP/SVP-BSW-3101577.yaml
+++ b/SVP/SVP-BSW-3101577.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BSW-3101577_v1.0.nc
     description: SVP-BSW-3101577 track

--- a/SVP/SVP-BSW-3101578.yaml
+++ b/SVP/SVP-BSW-3101578.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SVP-BSW-3101578_v1.0.nc
     description: SVP-BSW-3101578 track

--- a/SWIFT/SWIFT16.yaml
+++ b/SWIFT/SWIFT16.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SWIFT16_v1.0.nc
     description: SWIFT16 track

--- a/SWIFT/SWIFT17.yaml
+++ b/SWIFT/SWIFT17.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SWIFT17_v1.0.nc
     description: SWIFT17 track

--- a/SWIFT/SWIFT22.yaml
+++ b/SWIFT/SWIFT22.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SWIFT22_v1.0.nc
     description: SWIFT22 track

--- a/SWIFT/SWIFT23.yaml
+++ b/SWIFT/SWIFT23.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SWIFT23_v1.0.nc
     description: SWIFT23 track

--- a/SWIFT/SWIFT24.yaml
+++ b/SWIFT/SWIFT24.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SWIFT24_v1.0.nc
     description: SWIFT24 track

--- a/SWIFT/SWIFT25.yaml
+++ b/SWIFT/SWIFT25.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_SWIFT25_v1.0.nc
     description: SWIFT25 track

--- a/Skywalker/Skywalker07.yaml
+++ b/Skywalker/Skywalker07.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_Skywalker07_v1.0.nc
     description: Skywalker07 track

--- a/Skywalker/Skywalker10.yaml
+++ b/Skywalker/Skywalker10.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_Skywalker10_v1.0.nc
     description: Skywalker10 track

--- a/Skywalker/Skywalker12.yaml
+++ b/Skywalker/Skywalker12.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_Skywalker12_v1.0.nc
     description: Skywalker12 track

--- a/TO/main.yaml
+++ b/TO/main.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_TO_v1.0.nc
     description: TO track

--- a/WG/WG245.yaml
+++ b/WG/WG245.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_WG245_v1.0.nc
     description: WG245 track

--- a/WG/WG247.yaml
+++ b/WG/WG247.yaml
@@ -6,7 +6,7 @@ sources:
   track:
     args:
       auth: null
-      chunks: {}
+      chunks: null
       engine: netcdf4
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/TRACKS/EUREC4A_tracks_WG247_v1.0.nc
     description: WG247 track

--- a/barbados/bco.yaml
+++ b/barbados/bco.yaml
@@ -9,7 +9,7 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/BARBADOS/BCO/Raman_Lidar_CORAL/lowResolution/version_{{version}}/T{{dt}}min/nc/coral_{{date.strftime("%y%m%d")}}_0002_0000_{{content_type}}.nc
       auth: null
-      chunks: {}
+      chunks: null
     parameters:
       version:
         description: dataset version to use

--- a/radiative_profiles.yml
+++ b/radiative_profiles.yml
@@ -8,4 +8,4 @@ sources:
         args:
             urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/RADIATIVE-PROFILES/rad_profiles.nc
             auth: null
-            chunks: {}
+            chunks: null

--- a/satellites/goes16.yaml
+++ b/satellites/goes16.yaml
@@ -9,7 +9,7 @@ sources:
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/SATELLITES/GOES-E/{{resolution}}/{{date.strftime("%Y")}}/{{date.strftime("%Y_%m_%d")}}/GOES_{{'%02d' % (channel)}}_8N-18N-62W-50W_{{date.strftime("%Y%m%d")}}.nc
       auth: null
-      chunks: {}
+      chunks: null
     parameters:
       resolution:
         description: temporal and spacial resolution of gridded product

--- a/swifts.yml
+++ b/swifts.yml
@@ -7,40 +7,40 @@ sources:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT16_All_v2.1.nc
 
   SWIFT17:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT17_All_v2.1.nc
 
   SWIFT22:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT22_All_v2.1.nc
 
   SWIFT23:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT23_All_v2.1.nc
 
   SWIFT24:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT24_All_v2.1.nc
 
   SWIFT25:
     driver: opendap
     args:
       auth: null
-      chunks: {}
+      chunks: null
       urlpath: https://psl.noaa.gov/thredds/dodsC/Datasets/ATOMIC/data/swift_drifters/EUREC4A_ATOMIC_SWIFT25_All_v2.1.nc


### PR DESCRIPTION
There's an issue with the interworkings of dask and OPeNDAP: If dask
decides to do chunks on a dataset, it will request the whole chunk from
the backend storage, even if only a part of it is needed in the end.
However for OPeNDAP it is best to request only the required parts from
the backend. This change disables initial dask-chunking for all datasets
which previously used only a single chunk.

While this likely will improve performance for a lot of cases, it may
not always be the best solution. If multiple datasets are to be
concatenated, dask has to be used. However, in those cases, the user
maybe knows about chunking an will define those manually.