### PR TITLE
JOANNE: access netCDF files directly

### DIFF
--- a/JOANNE/main.yaml
+++ b/JOANNE/main.yaml
@@ -4,10 +4,14 @@ plugins:
 
 sources:
   level3:
-    driver: opendap
+    driver: netcdf
     description: EUREC4A/ATOMIC JOANNE Level-3 gridded dropsonde dataset
     args:
-      auth: null
       chunks: null
-      engine: netcdf4
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/MERGED-MEASUREMENTS/JOANNE/v2.0.0/Level_3/EUREC4A_JOANNE_Dropsonde-RD41_Level_3_v2.0.0.nc
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/PRODUCTS/MERGED-MEASUREMENTS/JOANNE/v2.0.0/Level_3/EUREC4A_JOANNE_Dropsonde-RD41_Level_3_v2.0.0.nc
+  level4:
+    driver: netcdf
+    description: EUREC4A/ATOMIC JOANNE Level-4 dropsonde dataset
+    args:
+      chunks: null
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/PRODUCTS/MERGED-MEASUREMENTS/JOANNE/v2.0.0/Level_4/EUREC4A_JOANNE_Dropsonde-RD41_Level_4_v2.0.0.nc

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -26,7 +26,7 @@ def test_get_intake_source(catalog, dataset_name):
     else:
         item.discover()
         plugin = item.describe()['plugin'][0]
-        if plugin in ["opendap", "zarr"]:
+        if plugin in ["opendap", "zarr", "netcdf"]:
             _ = item.to_dask()
         elif plugin in ["intake_esm.esm_datastore", "parquet"]:
             _ = item.get()


### PR DESCRIPTION
The datasets don't work nicely over OPeNDAP and accessing them directly
via netCDF seems to be the most pragmatic choice.

See also #78 and eurec4a/how_to_eurec4a#69.