### PR TITLE
ICON LES: add surface DOM02 output for controlRun

### DIFF
--- a/Simulations/ICON/LES_CampaignDomain_control.yaml
+++ b/Simulations/ICON/LES_CampaignDomain_control.yaml
@@ -11,6 +11,13 @@ sources:
     description: DOM01 surface fields
     driver: zarr
 
+  surface_DOM02:
+    args:
+      consolidated: true
+      urlpath: https://swift.dkrz.de/v1/dkrz_948e7d4bbfbb445fbff5315fc433e36a/EUREC4A_LES/experiment_2/ICON_DOM02_surface.zarr
+    description: DOM02 surface fields
+    driver: zarr
+
   rttov_DOM01:
     args:
       consolidated: true


### PR DESCRIPTION
This PR adds further output of the ICON LES simulations to the catalog