### PR TITLE
Add BCO MRR data

### DIFF
--- a/barbados/bco.yaml
+++ b/barbados/bco.yaml
@@ -67,3 +67,10 @@ sources:
         default: "v2.0.0"
         type: str
         allowed: ["v1.1.2", "v2.0.0"]
+
+  MRR:
+    description: Microwave rain radar measurements taken at the Barbados Cloud Observatory
+    driver: zarr
+    args:
+      urlpath: ipfs://QmeAL3DLEbWS2c2bkyA7mSgopN2ANmtMAGu79mM5GFQGhR
+      consolidated: true


### PR DESCRIPTION
How about some MRR data from the BCO? I thought I chunk the data that is available [on AERIS](https://observations.ipsl.fr/aeris/eurec4a-data/BARBADOS/BCO/MRR/v1.0.0/), pack it into a neat zarr file and provide it via IPFS. Currently, it's only pinned locally but am happy to pin it elsewhere.