### PR TITLE
corrected meteogram descriptions

### DIFF
--- a/Simulations/ICON/LES_CampaignDomain_control.yaml
+++ b/Simulations/ICON/LES_CampaignDomain_control.yaml
@@ -148,7 +148,7 @@ sources:
     args:
       consolidated: true
       urlpath: https://swift.dkrz.de/v1/dkrz_948e7d4bbfbb445fbff5315fc433e36a/EUREC4A_LES/experiment_2/meteograms/ICON_meteogram_DOM02_c_east.zarr
-    description: DOM01 meteogram at the HALO circle easternmost position
+    description: DOM02 meteogram at the HALO circle easternmost position
     driver: zarr
 
   synthetic_radar_c_east_DOM02:
@@ -176,7 +176,7 @@ sources:
     args:
       consolidated: true
       urlpath: https://swift.dkrz.de/v1/dkrz_948e7d4bbfbb445fbff5315fc433e36a/EUREC4A_LES/experiment_2/meteograms/ICON_meteogram_DOM02_c_north.zarr
-    description: DOM01 meteogram at the HALO circle northernmost position
+    description: DOM02 meteogram at the HALO circle northernmost position
     driver: zarr
 
   synthetic_radar_c_north_DOM02:


### PR DESCRIPTION
`meteogram_c_west_DOM02` and `meteogram_c_north_DOM02` were labeled as DOM01 in the description.

resolves #103