### PR TITLE
renamed weekly check pipeline

### DIFF
--- a/.github/workflows/weekly_tests.yml
+++ b/.github/workflows/weekly_tests.yml
@@ -5,7 +5,7 @@ on:
     - cron: '17 3 * * 0'
 
 jobs:
-  build:
+  weekly_check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I've got the suspicion that naming this `build` causes the PRs to wait for a week to be acceptable.