### PR TITLE
ICON-LES control: remove pressure level data

### DIFF
--- a/Simulations/ICON/LES_CampaignDomain_control.yaml
+++ b/Simulations/ICON/LES_CampaignDomain_control.yaml
@@ -32,20 +32,6 @@ sources:
     description: DOM02 synthetic satellite images via RTTOV (regridded)
     driver: zarr
 
-  pressure_level_DOM01:
-    args:
-      consolidated: true
-      urlpath: ipfs://bafybeigxhybtz4gv4l6477ixfzi66n6mj4oecu3gc4wlpdlipk2fvscokm
-    description: DOM01 selected pressure fields
-    driver: zarr
-
-  pressure_level_DOM02:
-    args:
-      consolidated: true
-      urlpath: https://swift.dkrz.de/v1/dkrz_948e7d4bbfbb445fbff5315fc433e36a/EUREC4A_LES/experiment_2/ICON_DOM02_pressure_lev.zarr
-    description: DOM02 selected pressure fields
-    driver: zarr
-
   meteogram_BCO_DOM01:
     args:
       consolidated: true


### PR DESCRIPTION
currently provided pressure level data is of little value
as its levels are in the upper troposphere and stratosphere