### PR TITLE
update waveglider v2.3 -> v2.4

### DIFF
--- a/WG/WG245.yaml
+++ b/WG/WG245.yaml
@@ -20,6 +20,6 @@ sources:
       auth: null
       chunks: null
       engine: netcdf4
-      urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/wavegliders/EUREC4A_ATOMIC_WG245_All_v2.3.nc
+      urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/wavegliders/EUREC4A_ATOMIC_WG245_All_v2.4.nc
     description: Wave glider 245, all data fields
     driver: opendap

--- a/WG/WG247.yaml
+++ b/WG/WG247.yaml
@@ -19,6 +19,6 @@ sources:
       auth: null
       chunks: null
       engine: netcdf4
-      urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/wavegliders/EUREC4A_ATOMIC_WG247_All_v2.3.nc
+      urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/wavegliders/EUREC4A_ATOMIC_WG247_All_v2.4.nc
     description: Wave glider 247, all data fields
     driver: opendap


### PR DESCRIPTION
Data at version 2.3 disappeared from the THREDDS server.