### PR TITLE
fix missing TSWindPres of SVP

### DIFF
--- a/SVP/SVP-BSW-3101569.yaml
+++ b/SVP/SVP-BSW-3101569.yaml
@@ -15,10 +15,11 @@ sources:
       tags:
       - track
       
-TSWindPres:
+  TSWindPres:
     args:
       auth: null
       chunks: null
+      engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/svp-s_drifters/EUREC4A_ATOMIC_drifter3101569_TSWindPres_v1.nc
     description: Temperature, Salinity, wind and pressure data from SVP drifters
     driver: opendap

--- a/SVP/SVP-BSW-3101570.yaml
+++ b/SVP/SVP-BSW-3101570.yaml
@@ -15,10 +15,11 @@ sources:
       tags:
       - track
       
-TSWindPres:
+  TSWindPres:
     args:
       auth: null
       chunks: null
+      engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/svp-s_drifters/EUREC4A_ATOMIC_drifter3101570_TSWindPres_v1.nc
     description: Temperature, Salinity, wind and pressure data from SVP drifters
     driver: opendap

--- a/SVP/SVP-BSW-3101571.yaml
+++ b/SVP/SVP-BSW-3101571.yaml
@@ -15,10 +15,11 @@ sources:
       tags:
       - track
       
-TSWindPres:
+  TSWindPres:
     args:
       auth: null
       chunks: null
+      engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/svp-s_drifters/EUREC4A_ATOMIC_drifter3101571_TSWindPres_v1.nc
     description: Temperature, Salinity, wind and pressure data from SVP drifters
     driver: opendap

--- a/SVP/SVP-BSW-3101572.yaml
+++ b/SVP/SVP-BSW-3101572.yaml
@@ -20,6 +20,6 @@ sources:
       auth: null
       chunks: null
       engine: netcdf4
-      urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/svp-s_drifters/EUREC4A_ATOMIC_drifter3101572_TSWindPres_v1.nc
+      urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/svp-s_drifters/EUREC4A_ATOMIC_drifter3101572_TSWindPres_v2.nc
     description: Temperature, Salinity, wind and pressure data from SVP drifters
     driver: opendap

--- a/SVP/SVP-BSW-3101572.yaml
+++ b/SVP/SVP-BSW-3101572.yaml
@@ -15,10 +15,11 @@ sources:
       tags:
       - track
       
-TSWindPres:
+  TSWindPres:
     args:
       auth: null
       chunks: null
+      engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/svp-s_drifters/EUREC4A_ATOMIC_drifter3101572_TSWindPres_v1.nc
     description: Temperature, Salinity, wind and pressure data from SVP drifters
     driver: opendap

--- a/SVP/SVP-BSW-3101573.yaml
+++ b/SVP/SVP-BSW-3101573.yaml
@@ -15,10 +15,11 @@ sources:
       tags:
       - track
       
-TSWindPres:
+  TSWindPres:
     args:
       auth: null
       chunks: null
+      engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/svp-s_drifters/EUREC4A_ATOMIC_drifter3101573_TSWindPres_v1.nc
     description: Temperature, Salinity, wind and pressure data from SVP drifters
     driver: opendap

--- a/SVP/SVP-BSW-3101574.yaml
+++ b/SVP/SVP-BSW-3101574.yaml
@@ -15,10 +15,11 @@ sources:
       tags:
       - track
       
-TSWindPres:
+  TSWindPres:
     args:
       auth: null
       chunks: null
+      engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/svp-s_drifters/EUREC4A_ATOMIC_drifter3101574_TSWindPres_v1.nc
     description: Temperature, Salinity, wind and pressure data from SVP drifters
     driver: opendap

--- a/SVP/SVP-BSW-3101575.yaml
+++ b/SVP/SVP-BSW-3101575.yaml
@@ -15,10 +15,11 @@ sources:
       tags:
       - track
       
-TSWindPres:
+  TSWindPres:
     args:
       auth: null
       chunks: null
+      engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/svp-s_drifters/EUREC4A_ATOMIC_drifter3101575_TSWindPres_v1.nc
     description: Temperature, Salinity, wind and pressure data from SVP drifters
     driver: opendap

--- a/SVP/SVP-BSW-3101576.yaml
+++ b/SVP/SVP-BSW-3101576.yaml
@@ -15,10 +15,11 @@ sources:
       tags:
       - track
       
-TSWindPres:
+  TSWindPres:
     args:
       auth: null
       chunks: null
+      engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/svp-s_drifters/EUREC4A_ATOMIC_drifter3101576_TSWindPres_v1.nc
     description: Temperature, Salinity, wind and pressure data from SVP drifters
     driver: opendap

--- a/SVP/SVP-BSW-3101577.yaml
+++ b/SVP/SVP-BSW-3101577.yaml
@@ -14,11 +14,3 @@ sources:
     metadata:
       tags:
       - track
-      
-TSWindPres:
-    args:
-      auth: null
-      chunks: null
-      urlpath: null
-    description: no data acquired
-    driver: opendap

--- a/SVP/SVP-BSW-3101578.yaml
+++ b/SVP/SVP-BSW-3101578.yaml
@@ -15,10 +15,11 @@ sources:
       tags:
       - track
       
-TSWindPres:
+  TSWindPres:
     args:
       auth: null
       chunks: null
+      engine: netcdf4
       urlpath: https://www.ncei.noaa.gov/thredds-ocean/dodsC/psl/atomic/svp-s_drifters/EUREC4A_ATOMIC_drifter3101578_TSWindPres_v1.nc
     description: Temperature, Salinity, wind and pressure data from SVP drifters
     driver: opendap

--- a/tests/test_yaml_files.py
+++ b/tests/test_yaml_files.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import yaml
+import pytest
+
+
+def root_path():
+    return Path(__file__).parent.parent
+
+
+def all_catalog_files():
+    root = root_path()
+    return [str(p.relative_to(root)) for p in sorted(root.glob("**/*.y*ml"))
+            if not p.match(".*/**/*")
+            and not p.match("tests/**/*")]
+
+
+@pytest.mark.parametrize("filename", all_catalog_files())
+def test_no_excess_keys(filename):
+    with open(root_path() / filename) as ifp:
+        data = yaml.load(ifp, Loader=yaml.SafeLoader)
+
+    excess = set(data) - {"plugins", "sources", "description"}
+    assert excess == set()


### PR DESCRIPTION
The `TSWindPres` data from the `SVP`s was not availaible in the catalog due to incorrectly formatted yaml files.

This PR fixes this and updates `SVP-BSW-3101572` to version 2, because v1 disappeared on thredds.

In order to prevent futher errors of this kind, this PR also includes a new unit test which checks if unexpected keys are found in the yaml catalog files.