### PR TITLE
Remove pydap dependency

### DIFF
--- a/HALO/BAHAMAS_PositionAttitude.yaml
+++ b/HALO/BAHAMAS_PositionAttitude.yaml
@@ -10,6 +10,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0118:
     driver: opendap
     args:
@@ -17,6 +18,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0119:
     driver: opendap
     args:
@@ -24,6 +26,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0122:
     driver: opendap
     args:
@@ -31,6 +34,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0124:
     driver: opendap
     args:
@@ -38,6 +42,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0126:
     driver: opendap
     args:
@@ -45,6 +50,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0128:
     driver: opendap
     args:
@@ -52,6 +58,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0130:
     driver: opendap
     args:
@@ -59,6 +66,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0131:
     driver: opendap
     args:
@@ -66,6 +74,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0202:
     driver: opendap
     args:
@@ -73,6 +82,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0205:
     driver: opendap
     args:
@@ -80,6 +90,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0207:
     driver: opendap
     args:
@@ -87,6 +98,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0209:
     driver: opendap
     args:
@@ -94,6 +106,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0211:
     driver: opendap
     args:
@@ -101,6 +114,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0213:
     driver: opendap
     args:
@@ -108,6 +122,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0215:
     driver: opendap
     args:
@@ -115,9 +130,11 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0218:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/ESSD_HALO_BAHAMAS_Subset/EUREC4A_HALO_BAHAMAS_PositionAttitude_20200218_v1.1.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/BAHAMAS_QL.yaml
+++ b/HALO/BAHAMAS_QL.yaml
@@ -10,6 +10,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0122:
     driver: opendap
     args:
@@ -17,6 +18,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0124:
     driver: opendap
     args:
@@ -24,6 +26,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0126:
     driver: opendap
     args:
@@ -31,6 +34,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0128:
     driver: opendap
     args:
@@ -38,6 +42,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0130:
     driver: opendap
     args:
@@ -45,6 +50,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0131:
     driver: opendap
     args:
@@ -52,6 +58,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0202:
     driver: opendap
     args:
@@ -59,6 +66,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0205:
     driver: opendap
     args:
@@ -66,6 +74,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0207:
     driver: opendap
     args:
@@ -73,6 +82,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0209:
     driver: opendap
     args:
@@ -80,6 +90,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0211:
     driver: opendap
     args:
@@ -87,6 +98,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0213:
     driver: opendap
     args:
@@ -94,6 +106,7 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0215:
     driver: opendap
     args:
@@ -101,9 +114,11 @@ sources:
       auth: null
       chunks: null
 
+      engine: netcdf4
   HALO-0218:
     driver: opendap
     args:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BAHAMAS/data/EUREC4A_HALO_BAHAMAS-QL-10Hz_20200218a.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/bacardi_irradiances.yaml
+++ b/HALO/bacardi_irradiances.yaml
@@ -10,6 +10,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200119/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200119_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0122:
     description: BACARDI irradiances.
     driver: opendap
@@ -17,6 +18,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200122/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200122_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0124:
     escription: BACARDI irradiances.
     driver: opendap
@@ -24,6 +26,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200124/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200124_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0126:
     escription: BACARDI irradiances.
     driver: opendap
@@ -31,6 +34,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200126/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200126_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0128:
     description: BACARDI irradiances.
     driver: opendap
@@ -38,6 +42,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200128/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200128_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0130:
     escription: BACARDI irradiances.
     driver: opendap
@@ -45,6 +50,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200130/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200130_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0131:
     escription: BACARDI irradiances.
     driver: opendap
@@ -52,6 +58,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200131/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200131_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0202:
     escription: BACARDI irradiances.
     driver: opendap
@@ -59,6 +66,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200202/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200202_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205:
     escription: BACARDI irradiances.
     driver: opendap
@@ -66,6 +74,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200205/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200205_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0207:
     escription: BACARDI irradiances.
     driver: opendap
@@ -73,6 +82,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200207/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200207_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0209:
     escription: BACARDI irradiances.
     driver: opendap
@@ -80,6 +90,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200209/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200209_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0211:
     description: BACARDI irradiances.
     driver: opendap
@@ -87,6 +98,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200211/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200211_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0213:
     escription: BACARDI irradiances.
     driver: opendap
@@ -94,6 +106,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200213/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200213_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0215:
     escription: BACARDI irradiances.
     driver: opendap
@@ -101,6 +114,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200215/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200215_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0218:
     escription: BACARDI irradiances.
     driver: opendap
@@ -108,3 +122,4 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/BACARDI/RF00_20200218/EUREC4A_HALO_BACARDI_BroadbandFluxes_20200218_R1.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/smart_irradiances.yaml
+++ b/HALO/smart_irradiances.yaml
@@ -10,6 +10,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF02_20200122/EUREC4A_HALO_SMART_spectral_irradiances_20200122_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0124:
     description: SMART spectral irradiances.
     driver: opendap
@@ -17,6 +18,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF03_20200124/EUREC4A_HALO_SMART_spectral_irradiances_20200124_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0126:
     description: SMART spectral irradiances.
     driver: opendap
@@ -24,6 +26,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF04_20200126/EUREC4A_HALO_SMART_spectral_irradiances_20200126_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0128:
     description: SMART spectral irradiances.
     driver: opendap
@@ -31,6 +34,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF05_20200128/EUREC4A_HALO_SMART_spectral_irradiances_20200128_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0130:
     description: SMART spectral irradiances.
     driver: opendap
@@ -38,6 +42,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF06_20200130/EUREC4A_HALO_SMART_spectral_irradiances_20200130_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0131:
     description: SMART spectral irradiances.
     driver: opendap
@@ -45,6 +50,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF07_20200131/EUREC4A_HALO_SMART_spectral_irradiances_20200131_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0202:
     description: SMART spectral irradiances.
     driver: opendap
@@ -52,6 +58,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF08_20200202/EUREC4A_HALO_SMART_spectral_irradiances_20200202_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205:
     description: SMART spectral irradiances.
     driver: opendap
@@ -59,6 +66,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF09_20200205/EUREC4A_HALO_SMART_spectral_irradiances_20200205_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0207:
     description: SMART spectral irradiances.
     driver: opendap
@@ -66,6 +74,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF10_20200207/EUREC4A_HALO_SMART_spectral_irradiances_20200207_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0209:
     description: SMART spectral irradiances.
     driver: opendap
@@ -73,6 +82,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF11_20200209/EUREC4A_HALO_SMART_spectral_irradiances_20200209_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0211:
     description: SMART spectral irradiances.
     driver: opendap
@@ -80,6 +90,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF12_20200211/EUREC4A_HALO_SMART_spectral_irradiances_20200211_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0213:
     description: SMART spectral irradiances.
     driver: opendap
@@ -87,6 +98,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF13_20200213/EUREC4A_HALO_SMART_spectral_irradiances_20200213_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0215:
     description: SMART spectral irradiances.
     driver: opendap
@@ -94,3 +106,4 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/SMART/2020/RF14_20200215/EUREC4A_HALO_SMART_spectral_irradiances_20200215_R3.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/specmacs/centroids.yaml
+++ b/HALO/specmacs/centroids.yaml
@@ -10,6 +10,7 @@ sources:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/centroids_HALO-0205_sl1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205_sl2:
     description: reduced form of points
     driver: opendap
@@ -17,6 +18,7 @@ sources:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/centroids_HALO-0205_sl2.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205_sl3:
     description: reduced form of points
     driver: opendap
@@ -24,6 +26,7 @@ sources:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/centroids_HALO-0205_sl3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205_sl4:
     description: reduced form of points
     driver: opendap
@@ -31,3 +34,4 @@ sources:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/centroids_HALO-0205_sl4.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/specmacs/mesh.yaml
+++ b/HALO/specmacs/mesh.yaml
@@ -10,6 +10,7 @@ sources:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/mesh_HALO-0205_sl1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205_sl2:
     description: cloud surfaces as determined by poisson reconstruction
     driver: opendap
@@ -17,6 +18,7 @@ sources:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/mesh_HALO-0205_sl2.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205_sl3:
     description: cloud surfaces as determined by poisson reconstruction
     driver: opendap
@@ -24,6 +26,7 @@ sources:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/mesh_HALO-0205_sl3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205_sl4:
     description: cloud surfaces as determined by poisson reconstruction
     driver: opendap
@@ -31,3 +34,4 @@ sources:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/mesh_HALO-0205_sl4.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/specmacs/points.yaml
+++ b/HALO/specmacs/points.yaml
@@ -10,6 +10,7 @@ sources:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/points_HALO-0205_sl1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205_sl2:
     description: points on cloud surface located by stereo method
     driver: opendap
@@ -17,6 +18,7 @@ sources:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/points_HALO-0205_sl2.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205_sl3:
     description: points on cloud surface located by stereo method
     driver: opendap
@@ -24,6 +26,7 @@ sources:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/points_HALO-0205_sl3.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205_sl4:
     description: points on cloud surface located by stereo method
     driver: opendap
@@ -31,3 +34,4 @@ sources:
       urlpath: https://macsserver.physik.uni-muenchen.de/products/dap/eurec4a/cloud_geometry/points_HALO-0205_sl4.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/unified/MWR_retrievals_unified.yaml
+++ b/HALO/unified/MWR_retrievals_unified.yaml
@@ -9,6 +9,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200119093425.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0122:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -16,6 +17,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200122145736.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0124:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -23,6 +25,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200124092931.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0126:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -30,6 +33,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200126120530.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0128:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -37,6 +41,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200128145834.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0130:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -44,6 +49,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200130111934.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0131:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -51,6 +57,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200131150836.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0202:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -58,6 +65,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200202112802.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -65,6 +73,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200205091552.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0207:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -72,6 +81,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200207120224.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0209:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -79,6 +89,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200209091432.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0211:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -86,6 +97,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200211122905.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0213:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -93,6 +105,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200213075611.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0215:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -100,6 +113,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200215150731.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0218:
     description: HAMP Microwave Radiometer retrieval products of LWP, RWP and IWV
     driver: opendap
@@ -107,3 +121,4 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/HAMP/LWP_IWV_v0.9.2/EUREC4A_HALO_HAMP_lwpiwv_l2_any_v0.9.2_20200218101105.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/unified/bahamas_unified.yaml
+++ b/HALO/unified/bahamas_unified.yaml
@@ -9,6 +9,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200119_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0122:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -16,6 +17,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200122_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0124:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -23,6 +25,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200124_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0126:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -30,6 +33,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200126_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0128:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -37,6 +41,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200128_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0130:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -44,6 +49,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200130_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0131:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -51,6 +57,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200131_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0202:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -58,6 +65,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200202_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -65,6 +73,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200205_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0207:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -72,6 +81,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200207_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0209:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -79,6 +89,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200209_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0211:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -86,6 +97,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200211_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0213:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -93,6 +105,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200213_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0215:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -100,6 +113,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200215_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0218:
     description: bahamas data from the HALO unified dataset.
     driver: opendap
@@ -107,3 +121,4 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_bahamas_20200218_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/unified/dropsondes_unified.yaml
+++ b/HALO/unified/dropsondes_unified.yaml
@@ -9,6 +9,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200119_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0122:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -16,6 +17,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200122_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0124:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -23,6 +25,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200124_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0126:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -30,6 +33,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200126_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0128:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -37,6 +41,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200128_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0130:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -44,6 +49,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200130_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0131:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -51,6 +57,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200131_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0202:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -58,6 +65,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200202_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -65,6 +73,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200205_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0207:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -72,6 +81,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200207_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0209:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -79,6 +89,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200209_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0211:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -86,6 +97,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200211_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0213:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -93,6 +105,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200213_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0215:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -100,6 +113,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200215_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0218:
     description: dropsondes data from the HALO unified dataset.
     driver: opendap
@@ -107,3 +121,4 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_dropsondes_20200218_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/unified/radar_unified.yaml
+++ b/HALO/unified/radar_unified.yaml
@@ -9,6 +9,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200119_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0122:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -16,6 +17,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200122_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0124:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -23,6 +25,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200124_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0126:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -30,6 +33,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200126_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0128:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -37,6 +41,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200128_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0130:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -44,6 +49,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200130_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0131:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -51,6 +57,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200131_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0202:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -58,6 +65,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200202_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -65,6 +73,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200205_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0207:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -72,6 +81,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200207_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0209:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -79,6 +89,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200209_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0211:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -86,6 +97,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200211_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0213:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -93,6 +105,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200213_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0215:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -100,6 +113,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200215_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0218:
     description: radar data from the HALO unified dataset.
     driver: opendap
@@ -107,3 +121,4 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radar_20200218_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/unified/radiometer_unified.yaml
+++ b/HALO/unified/radiometer_unified.yaml
@@ -9,6 +9,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200119_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0122:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -16,6 +17,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200122_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0124:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -23,6 +25,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200124_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0126:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -30,6 +33,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200126_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0128:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -37,6 +41,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200128_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0130:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -44,6 +49,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200130_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0131:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -51,6 +57,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200131_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0202:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -58,6 +65,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200202_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -65,6 +73,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200205_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0207:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -72,6 +81,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200207_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0209:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -79,6 +89,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200209_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0211:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -86,6 +97,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200211_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0213:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -93,6 +105,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200213_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0215:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -100,6 +113,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200215_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0218:
     description: radiometer data from the HALO unified dataset.
     driver: opendap
@@ -107,3 +121,4 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/UNIFIED/EUREC4A_HALO_radiometer_20200218_v0.9.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/wales/wales_adepg.yaml
+++ b/HALO/wales/wales_adepg.yaml
@@ -9,6 +9,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_22/EUREC4A_HALO_WALES_adepg_20200122a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0124:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
@@ -16,6 +17,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_24/EUREC4A_HALO_WALES_adepg_20200124a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0126:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
@@ -23,6 +25,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_26/EUREC4A_HALO_WALES_adepg_20200126a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0128:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
@@ -30,6 +33,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_28/EUREC4A_HALO_WALES_adepg_20200128a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0130:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
@@ -37,6 +41,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_30/EUREC4A_HALO_WALES_adepg_20200130a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0131:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
@@ -44,6 +49,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_31/EUREC4A_HALO_WALES_adepg_20200131a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0202:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
@@ -51,6 +57,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_02/EUREC4A_HALO_WALES_adepg_20200202a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
@@ -58,6 +65,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_05/EUREC4A_HALO_WALES_adepg_20200205a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0207:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
@@ -65,6 +73,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_07/EUREC4A_HALO_WALES_adepg_20200207a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0209:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
@@ -72,6 +81,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_09/EUREC4A_HALO_WALES_adepg_20200209a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0211:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
@@ -79,6 +89,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_11/EUREC4A_HALO_WALES_adepg_20200211a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0213:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
@@ -86,6 +97,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_13/EUREC4A_HALO_WALES_adepg_20200213a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0215:
     description: WALES-Lidar Particle Depolarisation at 532 nm.
     driver: opendap
@@ -93,3 +105,4 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_15/EUREC4A_HALO_WALES_adepg_20200215a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/wales/wales_bsrg.yaml
+++ b/HALO/wales/wales_bsrg.yaml
@@ -9,6 +9,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_22/EUREC4A_HALO_WALES_bsrg_20200122a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0124:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
@@ -16,6 +17,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_24/EUREC4A_HALO_WALES_bsrg_20200124a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0126:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
@@ -23,6 +25,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_26/EUREC4A_HALO_WALES_bsrg_20200126a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0128:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
@@ -30,6 +33,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_28/EUREC4A_HALO_WALES_bsrg_20200128a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0130:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
@@ -37,6 +41,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_30/EUREC4A_HALO_WALES_bsrg_20200130a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0131:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
@@ -44,6 +49,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_31/EUREC4A_HALO_WALES_bsrg_20200131a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0202:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
@@ -51,6 +57,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_02/EUREC4A_HALO_WALES_bsrg_20200202a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
@@ -58,6 +65,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_05/EUREC4A_HALO_WALES_bsrg_20200205a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0207:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
@@ -65,6 +73,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_07/EUREC4A_HALO_WALES_bsrg_20200207a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0209:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
@@ -72,6 +81,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_09/EUREC4A_HALO_WALES_bsrg_20200209a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0211:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
@@ -79,6 +89,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_11/EUREC4A_HALO_WALES_bsrg_20200211a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0213:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
@@ -86,6 +97,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_13/EUREC4A_HALO_WALES_bsrg_20200213a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0215:
     description: WALES-Lidar Backscatter Ratio at 532 nm (parallel polarisation).
     driver: opendap
@@ -93,3 +105,4 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_15/EUREC4A_HALO_WALES_bsrg_20200215a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/wales/wales_bsri.yaml
+++ b/HALO/wales/wales_bsri.yaml
@@ -9,6 +9,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_22/EUREC4A_HALO_WALES_bsri_20200122a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0124:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
@@ -16,6 +17,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_24/EUREC4A_HALO_WALES_bsri_20200124a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0126:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
@@ -23,6 +25,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_26/EUREC4A_HALO_WALES_bsri_20200126a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0128:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
@@ -30,6 +33,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_28/EUREC4A_HALO_WALES_bsri_20200128a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0130:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
@@ -37,6 +41,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_30/EUREC4A_HALO_WALES_bsri_20200130a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0131:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
@@ -44,6 +49,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_31/EUREC4A_HALO_WALES_bsri_20200131a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0202:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
@@ -51,6 +57,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_02/EUREC4A_HALO_WALES_bsri_20200202a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
@@ -58,6 +65,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_05/EUREC4A_HALO_WALES_bsri_20200205a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0207:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
@@ -65,6 +73,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_07/EUREC4A_HALO_WALES_bsri_20200207a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0209:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
@@ -72,6 +81,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_09/EUREC4A_HALO_WALES_bsri_20200209a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0211:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
@@ -79,6 +89,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_11/EUREC4A_HALO_WALES_bsri_20200211a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0213:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
@@ -86,6 +97,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_13/EUREC4A_HALO_WALES_bsri_20200213a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0215:
     description: WALES-Lidar Backscatter Ratio at 1064 nm (parallel polarisation).
     driver: opendap
@@ -93,3 +105,4 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_15/EUREC4A_HALO_WALES_bsri_20200215a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/HALO/wales/wales_wv.yaml
+++ b/HALO/wales/wales_wv.yaml
@@ -9,6 +9,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_22/EUREC4A_HALO_WALES_wv_20200122a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0124:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
@@ -16,6 +17,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_24/EUREC4A_HALO_WALES_wv_20200124a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0126:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
@@ -23,6 +25,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_26/EUREC4A_HALO_WALES_wv_20200126a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0128:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
@@ -30,6 +33,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_28/EUREC4A_HALO_WALES_wv_20200128a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0130:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
@@ -37,6 +41,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_30/EUREC4A_HALO_WALES_wv_20200130a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0131:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
@@ -44,6 +49,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_01_31/EUREC4A_HALO_WALES_wv_20200131a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0202:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
@@ -51,6 +57,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_02/EUREC4A_HALO_WALES_wv_20200202a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0205:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
@@ -58,6 +65,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_05/EUREC4A_HALO_WALES_wv_20200205a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0207:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
@@ -65,6 +73,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_07/EUREC4A_HALO_WALES_wv_20200207a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0209:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
@@ -72,6 +81,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_09/EUREC4A_HALO_WALES_wv_20200209a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0211:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
@@ -79,6 +89,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_11/EUREC4A_HALO_WALES_wv_20200211a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0213:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
@@ -86,6 +97,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_13/EUREC4A_HALO_WALES_wv_20200213a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4
   HALO-0215:
     description: WALES-Lidar water vapour volume mixing ratio in ppm.
     driver: opendap
@@ -93,3 +105,4 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/AIRCRAFT/HALO/WALES-LIDAR/2020/2020_02_15/EUREC4A_HALO_WALES_wv_20200215a_V1.nc
       auth: null
       chunks: null
+      engine: netcdf4

--- a/Meteor/LIMRAD94.yaml
+++ b/Meteor/LIMRAD94.yaml
@@ -10,6 +10,7 @@ sources:
       auth: null
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/SHIPS/RV-METEOR/cloudradar/low-res-reflectivity-ncfiles/RV-METEOR_LIMRAD94_Ze_{{date.strftime("%Y%m%d")}}.nc
       chunks: {time: 1000}
+      engine: netcdf4
     parameters:
       date:
         description: date of observation
@@ -25,6 +26,7 @@ sources:
       auth: null
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/SHIPS/RV-METEOR/cloudradar/heave-corr-high-res-ncfiles/eurec4a_rv-meteor_cloudradar_{{date.strftime("%Y%m%d")}}_v{{version}}.nc
       chunks: {time: 1000}
+      engine: netcdf4
     parameters:
       date:
         description: date of observation

--- a/SD/SD-1026.yaml
+++ b/SD/SD-1026.yaml
@@ -20,6 +20,7 @@ sources:
       auth: null
       chunks: null
       urlpath: https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1026-20200117T000000-20200302T235959-1_minutes-v1.1595708344687.nc
+      engine: netcdf4
     description: Saildrone 1026, one minute data
     driver: opendap
 
@@ -28,5 +29,6 @@ sources:
       auth: null
       chunks: null
       urlpath: https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1026-20200117T000000-20200302T235959-5_minutes-v1.1595997001389.nc
+      engine: netcdf4
     description: Saildrone 1026, five minute data 
     driver: opendap

--- a/SD/SD-1026.yaml
+++ b/SD/SD-1026.yaml
@@ -17,18 +17,14 @@ sources:
 
   1min:
     args:
-      auth: null
       chunks: null
-      urlpath: https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1026-20200117T000000-20200302T235959-1_minutes-v1.1595708344687.nc
-      engine: netcdf4
+      urlpath: simplecache::https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1026-20200117T000000-20200302T235959-1_minutes-v1.1595708344687.nc
     description: Saildrone 1026, one minute data
-    driver: opendap
+    driver: netcdf
 
   5min:
     args:
-      auth: null
       chunks: null
-      urlpath: https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1026-20200117T000000-20200302T235959-5_minutes-v1.1595997001389.nc
-      engine: netcdf4
+      urlpath: simplecache::https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1026-20200117T000000-20200302T235959-5_minutes-v1.1595997001389.nc
     description: Saildrone 1026, five minute data 
-    driver: opendap
+    driver: netcdf

--- a/SD/SD-1060.yaml
+++ b/SD/SD-1060.yaml
@@ -13,13 +13,14 @@ sources:
     driver: opendap
     metadata:
       tags:
-      - track
+        - track
 
   1min:
     args:
       auth: null
       chunks: null
       urlpath: https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1060-20200117T000000-20200302T235959-1_minutes-v1.1595708144897.nc
+      engine: netcdf4
     description: Saildrone 1060, one minute data
     driver: opendap
 
@@ -28,5 +29,6 @@ sources:
       auth: null
       chunks: null
       urlpath: https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1060-20200117T000000-20200302T235959-5_minutes-v1.1595997115384.nc
+      engine: netcdf4
     description: Saildrone 1060, five minute data 
     driver: opendap

--- a/SD/SD-1060.yaml
+++ b/SD/SD-1060.yaml
@@ -17,18 +17,14 @@ sources:
 
   1min:
     args:
-      auth: null
       chunks: null
-      urlpath: https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1060-20200117T000000-20200302T235959-1_minutes-v1.1595708144897.nc
-      engine: netcdf4
+      urlpath: simplecache::https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1060-20200117T000000-20200302T235959-1_minutes-v1.1595708144897.nc
     description: Saildrone 1060, one minute data
-    driver: opendap
+    driver: netcdf
 
   5min:
     args:
-      auth: null
       chunks: null
-      urlpath: https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1060-20200117T000000-20200302T235959-5_minutes-v1.1595997115384.nc
-      engine: netcdf4
+      urlpath: simplecache::https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1060-20200117T000000-20200302T235959-5_minutes-v1.1595997115384.nc
     description: Saildrone 1060, five minute data 
-    driver: opendap
+    driver: netcdf

--- a/SD/SD-1061.yaml
+++ b/SD/SD-1061.yaml
@@ -13,13 +13,14 @@ sources:
     driver: opendap
     metadata:
       tags:
-      - track
+        - track
 
   1min:
     args:
       auth: null
       chunks: null
       urlpath: https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1061-20200117T000000-20200302T235959-1_minutes-v1.1595707641693.nc
+      engine: netcdf4
     description: Saildrone 1061, one minute data
     driver: opendap
 
@@ -28,5 +29,6 @@ sources:
       auth: null
       chunks: null
       urlpath: https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1061-20200117T000000-20200302T235959-5_minutes-v1.1595997706709.nc
+      engine: netcdf4
     description: Saildrone 1061, five minute data 
     driver: opendap

--- a/SD/SD-1061.yaml
+++ b/SD/SD-1061.yaml
@@ -17,18 +17,14 @@ sources:
 
   1min:
     args:
-      auth: null
       chunks: null
-      urlpath: https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1061-20200117T000000-20200302T235959-1_minutes-v1.1595707641693.nc
-      engine: netcdf4
+      urlpath: simplecache::https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1061-20200117T000000-20200302T235959-1_minutes-v1.1595707641693.nc
     description: Saildrone 1061, one minute data
-    driver: opendap
+    driver: netcdf
 
   5min:
     args:
-      auth: null
       chunks: null
-      urlpath: https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1061-20200117T000000-20200302T235959-5_minutes-v1.1595997706709.nc
-      engine: netcdf4
+      urlpath: simplecache::https://podaac-opendap.jpl.nasa.gov/opendap/allData/insitu/L2/saildrone/Atomic/saildrone-gen_5-atomic_eurec4a_2020-sd1061-20200117T000000-20200302T235959-5_minutes-v1.1595997706709.nc
     description: Saildrone 1061, five minute data 
-    driver: opendap
+    driver: netcdf

--- a/barbados/BCO/bco.yaml
+++ b/barbados/BCO/bco.yaml
@@ -5,12 +5,10 @@ plugins:
 sources:
   CORAL_LIDAR:
     description: Observations made with the CORAL LIDAR at BCO
-    driver: opendap
+    driver: netcdf
     args:
-      urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/BARBADOS/BCO/Raman_Lidar_CORAL/lowResolution/version_{{version}}/T{{dt}}min/nc/coral_{{date.strftime("%y%m%d")}}_0002_0000_{{content_type}}.nc
-      auth: null
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/BARBADOS/BCO/Raman_Lidar_CORAL/lowResolution/version_{{version}}/T{{dt}}min/nc/coral_{{date.strftime("%y%m%d")}}_0002_0000_{{content_type}}.nc
       chunks: null
-      engine: netcdf4
     parameters:
       version:
         description: dataset version to use

--- a/barbados/BCO/bco.yaml
+++ b/barbados/BCO/bco.yaml
@@ -10,6 +10,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/BARBADOS/BCO/Raman_Lidar_CORAL/lowResolution/version_{{version}}/T{{dt}}min/nc/coral_{{date.strftime("%y%m%d")}}_0002_0000_{{content_type}}.nc
       auth: null
       chunks: null
+      engine: netcdf4
     parameters:
       version:
         description: dataset version to use

--- a/radiative_profiles.yml
+++ b/radiative_profiles.yml
@@ -9,6 +9,7 @@ sources:
             urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/RADIATIVE-PROFILES/rad_profiles_{{version}}.nc
             auth: null
             chunks: null
+            engine: netcdf4
         parameters:
             version:
                 description: "dataset version"

--- a/radiosondes.yml
+++ b/radiosondes.yml
@@ -9,6 +9,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/MERGED-MEASUREMENTS/RADIOSOUNDINGS/v3.0.0/level2/EUREC4A_Atalante_Meteomodem-RS_L2_v3.0.0.nc
       auth: null
       chunks: null
+      engine: netcdf4
     description: Meteomodem-RS on Atalante
   atalante_vaisala:
     driver: opendap
@@ -16,6 +17,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/MERGED-MEASUREMENTS/RADIOSOUNDINGS/v3.0.0/level2/EUREC4A_Atalante_Vaisala-RS_L2_v3.0.0.nc
       auth: null
       chunks: null
+      engine: netcdf4
     description: Vaisala-RS on Atalante
   bco:
     driver: opendap
@@ -23,6 +25,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/MERGED-MEASUREMENTS/RADIOSOUNDINGS/v3.0.0/level2/EUREC4A_BCO_Vaisala-RS_L2_v3.0.0.nc
       auth: null
       chunks: null
+      engine: netcdf4
     description: Vaisala-RS on BCO
   meteor:
     driver: opendap
@@ -30,6 +33,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/MERGED-MEASUREMENTS/RADIOSOUNDINGS/v3.0.0/level2/EUREC4A_Meteor_Vaisala-RS_L2_v3.0.0.nc
       auth: null
       chunks: null
+      engine: netcdf4
     description: Vaisala-RS on Meteor
   ms_merian:
     driver: opendap
@@ -37,6 +41,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/MERGED-MEASUREMENTS/RADIOSOUNDINGS/v3.0.0/level2/EUREC4A_BCO_Vaisala-RS_L2_v3.0.0.nc
       auth: null
       chunks: null
+      engine: netcdf4
     description: Vaisala-RS on MS-Merian
   ronbrown:
     driver: opendap
@@ -44,4 +49,5 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/PRODUCTS/MERGED-MEASUREMENTS/RADIOSOUNDINGS/v3.0.0/level2/EUREC4A_RonBrown_Vaisala-RS_L2_v3.0.0.nc
       auth: null
       chunks: null
+      engine: netcdf4
     description: Vaisala-RS on RonBrown

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ intake[dataframe] # since intake 0.6.1 to_dask() doesn't work anymore without th
 xarray
 zarr
 fsspec>=0.7.4
-pydap
 netcdf4!=1.5.4,!=1.5.5,!=1.5.5.1 # this is due to https://github.com/Unidata/netcdf4-python/issues/1052
 s3fs
 ipfsspec

--- a/satellites/goes16.yaml
+++ b/satellites/goes16.yaml
@@ -10,6 +10,7 @@ sources:
       urlpath: https://observations.ipsl.fr/thredds/dodsC/EUREC4A/SATELLITES/GOES-E/{{resolution}}/{{date.strftime("%Y")}}/{{date.strftime("%Y_%m_%d")}}/GOES_{{'%02d' % (channel)}}_8N-18N-62W-50W_{{date.strftime("%Y%m%d")}}.nc
       auth: null
       chunks: null
+      engine: netcdf4
     parameters:
       resolution:
         description: temporal and spacial resolution of gridded product


### PR DESCRIPTION
Pydap was causing troubles on an on and as we require netCDF anyways, we could also just use netCDF for accessing opendap resources. This PR sets all opendap resources to be accessed via netCDF.

During creation of this PR, another issue surfaced: some netCDF datasets are incompatible with the classic data model of netCDF (which is assumed to be the opendap data model by several clients). This PR changes access to the affected datasets to direct download of the original netCDF files (using `simplecache`) and opens those files as local netCDF files. I expect this to be a good trade-off, as the relevant netCDF files are rather small (several MB).