### PR TITLE
remove item.discover() in tests

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -40,7 +40,6 @@ def test_get_intake_source(catalog, dataset_name):
     if item.container == "catalog":
         item.reload()
     else:
-        item.discover()
         plugin = item.describe()['plugin'][0]
         if plugin in ["opendap", "zarr", "netcdf"]:
             _ = item.to_dask()


### PR DESCRIPTION
discover is seemingly not implemented for all data sources, thus this
test can fail for the wrong reasons. Until discover is implemented for
all sources (if that happens at all) we'll have to specialize (meta-)
data loading in tests to each driver.

fixes #102