### PR TITLE
change python version to 3.8

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies (pip)
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/weekly_tests.yml
+++ b/.github/workflows/weekly_tests.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies (pip)
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
The [current failure](https://github.com/eurec4a/eurec4a-intake/actions/runs/3167336245/jobs/5157754971#step:5:37792) of the weekly test made me think that it could be a good time to finally switch to python3.8 for the tests.