### PR TITLE
allow manual running of weekly_test

### DIFF
--- a/.github/workflows/weekly_tests.yml
+++ b/.github/workflows/weekly_tests.yml
@@ -3,6 +3,7 @@ name: eurec4a_intake
 on:
   schedule:
     - cron: '17 3 * * 0'
+  workflow_dispatch:
 
 jobs:
   weekly_check:


### PR DESCRIPTION
Allow manual triggering of workflow `weekly_test` because it is not triggered when testing PRs (which is good), but when fixing failures of `weekly_test` it would be necessary

see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow