### PR TITLE
add DALES simulations botany_dx100m_nx96

### DIFF
--- a/Simulations/DALES/botany_dx100m.yaml
+++ b/Simulations/DALES/botany_dx100m.yaml
@@ -6,6 +6,13 @@ sources:
   nx1536:
     args:
       path: "{{CATALOG_DIR}}/botany_dx100m_nx1536.yaml"
-    description: 'Cloud botany: DALES LES ensemble with varied forcings at 100m grid spacing'
+    description: 'Cloud botany: DALES LES ensemble with varied forcings at 100m grid spacing, 153.6 km domain'
+    driver: yaml_file_cat
+    metadata: {}
+
+  nx96:
+    args:
+      path: "{{CATALOG_DIR}}/botany_dx100m_nx96.yaml"
+    description: 'Cloud botany: DALES LES ensemble with varied forcings at 100m grid spacing, 9.6 km domain'
     driver: yaml_file_cat
     metadata: {}

--- a/Simulations/DALES/botany_dx100m_nx1536.yaml
+++ b/Simulations/DALES/botany_dx100m_nx1536.yaml
@@ -7,14 +7,14 @@ sources:
     args:
       consolidated: true
       urlpath: https://swift.dkrz.de/v1/dkrz_b42c6bc6-439f-4efb-9491-db3de70ad9ba/botany_1536_01D/botany_1536_profiles.zarr
-    description: profiles
+    description: Profiles, horizontally averaged
     driver: zarr
 
   timeseries:
     args:
       consolidated: true
       urlpath: https://swift.dkrz.de/v1/dkrz_b42c6bc6-439f-4efb-9491-db3de70ad9ba/botany_1536_01D/botany_1536_timeseries.zarr
-    description: timeseries
+    description: Timeseries of domain means
     driver: zarr
 
   2D:

--- a/Simulations/DALES/botany_dx100m_nx96.yaml
+++ b/Simulations/DALES/botany_dx100m_nx96.yaml
@@ -1,0 +1,53 @@
+plugins:
+  source:
+    - module: intake_xarray
+
+sources:
+  profiles:
+    args:
+      consolidated: true
+      urlpath: https://swift.dkrz.de/v1/dkrz_b42c6bc6-439f-4efb-9491-db3de70ad9ba/botany_96_01D/botany_96_profiles.zarr
+    description: Profiles, horizontally averaged
+    driver: zarr
+
+  timeseries:
+    args:
+      consolidated: true
+      urlpath: https://swift.dkrz.de/v1/dkrz_b42c6bc6-439f-4efb-9491-db3de70ad9ba/botany_96_01D/botany_96_timeseries.zarr
+    description: Timeseries of domain means
+    driver: zarr
+
+  2D:
+    args:
+      consolidated: true
+      urlpath: https://swift.dkrz.de/v1/dkrz_b42c6bc6-439f-4efb-9491-db3de70ad9ba/botany_96_2D/botany_96_2D.zarr
+    description: 2D fields
+    driver: zarr
+
+  3D:
+    args:
+      consolidated: true
+      urlpath: https://swift.dkrz.de/v1/dkrz_b42c6bc6-439f-4efb-9491-db3de70ad9ba/botany_96_3D/botany_96_3D.zarr
+    description: 3D fields
+    driver: zarr
+
+  cross_xy:
+    args:
+      consolidated: true
+      urlpath: https://swift.dkrz.de/v1/dkrz_b42c6bc6-439f-4efb-9491-db3de70ad9ba/botany_96_cross_xy/botany_96_cross_xy.zarr
+    description: XY cross-sections
+    driver: zarr
+
+  radiation:
+    args:
+      consolidated: true
+      urlpath: https://swift.dkrz.de/v1/dkrz_b42c6bc6-439f-4efb-9491-db3de70ad9ba/botany_96_radiation/botany_96_radiation.zarr
+    description: Radiation fields
+    driver: zarr
+
+  parameters:
+    args:
+      urlpath: https://swift.dkrz.de/v1/dkrz_b42c6bc6-439f-4efb-9491-db3de70ad9ba/botany_96_01D/botany_96_params_records.json.zip
+      compression: zip
+    description: Parameters of experiments
+    driver: json


### PR DESCRIPTION
similar to the previous botany_dx_100m_nx1536, except:
* the domain size is smaller, 96 cells horizontally
* the simulation time is longer, 7 days.

Test script, to access the new datasets (loading catalog from my fork of the eurec4a-intake catalog):
```python
import matplotlib.pyplot as plt
import pandas as pd
from intake import open_catalog

url ="https://raw.githubusercontent.com/fjansson/eurec4a-intake/botany-96/Simulations/DALES/botany.yaml"
cat = open_catalog(url)

parameters = cat.dx100m.nx96.parameters.read()
varied_parameters = ['member','thls', 'u0', 'qt0', 'qt_lambda', 'thl_Gamma', 'wpamp', 'dudz', 'location']
df_parameters = pd.DataFrame.from_records(parameters)[varied_parameters]
print(df_parameters)

ds_2D = cat.dx100m.nx96['2D'].to_dask()
print(ds_2D)

ds_3D = cat.dx100m.nx96['3D'].to_dask()
print(ds_3D)

ds_radiation = cat.dx100m.nx96['radiation'].to_dask()
print(ds_radiation)

ds_cross_xy = cat.dx100m.nx96['cross_xy'].to_dask()
print(ds_cross_xy)

ds_profiles = cat.dx100m.nx96['profiles'].to_dask()
print(ds_profiles)

ds_timeseries = cat.dx100m.nx96['timeseries'].to_dask()
print(ds_timeseries)

# plot a 2D field
ds_2D.sel(member=10).isel(time=400).twp.plot()

# plot same field from the larger botany simulation
plt.figure()
ds_2D_large = cat.dx100m.nx1536['2D'].to_dask()
ds_2D_large.sel(member=10).isel(time=400).twp.plot()
plt.show()
```