### PR TITLE
Fix CI badge

### DIFF
--- a/.github/workflows/weekly_tests.yml
+++ b/.github/workflows/weekly_tests.yml
@@ -1,4 +1,4 @@
-name: eurec4a_intake
+name: Weekly Dataset Availability Test
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EUREC4A Intake catalogue
 
-![weekly_tests.yml](https://img.shields.io/github/actions/workflow/status/eurec4a/eurec4a-intake/weekly_tests.yml?label=Weekly%20Dataset%20Availability%20Test&link=https%3A%2F%2Fgithub.com%2Feurec4a%2Feurec4a-intake%2Factions%2Fworkflows%2Fweekly_tests.yml)
+![weekly_tests.yml](https://github.com/eurec4a/eurec4a-intake/actions/workflows/weekly_tests.yml/badge.svg)
  [![](https://zenodo.org/badge/doi/10.5281/zenodo.8422321.svg)](https://doi.org/10.5281/zenodo.8422321)
 
 This repository contains an [intake](https://github.com/intake/intake)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # EUREC4A Intake catalogue
 
-![eurec4a_intake](https://github.com/eurec4a/eurec4a-intake/workflows/eurec4a_intake/badge.svg) [![](https://zenodo.org/badge/doi/10.5281/zenodo.8422321.svg)](https://doi.org/10.5281/zenodo.8422321)
+![weekly_tests.yml](https://img.shields.io/github/actions/workflow/status/eurec4a/eurec4a-intake/weekly_tests.yml?label=Weekly%20Dataset%20Availability%20Test&link=https%3A%2F%2Fgithub.com%2Feurec4a%2Feurec4a-intake%2Factions%2Fworkflows%2Fweekly_tests.yml)
+ [![](https://zenodo.org/badge/doi/10.5281/zenodo.8422321.svg)](https://doi.org/10.5281/zenodo.8422321)
 
 This repository contains an [intake](https://github.com/intake/intake)
 catalogue for acessing data from  the [EUREC4A field


### PR DESCRIPTION
The badge on the readme page (https://github.com/eurec4a/eurec4a-intake/workflows/eurec4a_intake/badge.svg) does not work correctly, e.g. it is currently set to "failing" although all pipelines succeed. The link seems to be non-standard and since we have two workflows with the same name (`eurec4a_intake`) some confusion might be caused. This PR does:

- fix link to badge
- use weekly_tests.yml as main health indicator
- change test name to be more descriptive