### PR TITLE
Add gridded POLDIRAD dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add LICHT lidar data from RV Meteor as provided by the MPI-TCO catalog (#12). By [Leif Denby](https://github.com/leifdenby), [Hauke Schulz](https://github.com/observingClouds), [Tobias Kölling](https://github.com/d70-t) and [Nina Robbins](https://github.com/ninarobbins)
 ### Updated Datasets
 * Updated RV Meteor cloud radar data (LIMRAD94) to version 1.2, in which the variable hydrometeor_mask was added which tells you whether there is a signal in the processed reflectivity or not
+* Add gridded POLDIRAD product with kerchunk references to provide a continous dataset (#160). By [Hauke Schulz](https://github.com/observingClouds)
 ### Removed Datasets
 ### Fixes
 ### Internal Changes

--- a/barbados/BCO/bco.yaml
+++ b/barbados/BCO/bco.yaml
@@ -44,6 +44,13 @@ sources:
     driver: yaml_file_cat
     metadata: {}
 
+  POLDIRAD:
+    args:
+      path: "{{CATALOG_DIR}}/poldirad.yaml"
+    description: 'C-band Polarimetric Doppler radar (POLDIRAD)'
+    driver: yaml_file_cat
+    metadata: {}
+
   radar_reflectivity:
     description: Radar reflectivities measured with the Ka-Band radar at the Barbados Cloud Observatory.
     driver: zarr
@@ -91,5 +98,4 @@ sources:
       chunks: null
     metadata:
       maintainer: Leonie Villiger <leonie.villiger[at]env.ethz.ch>, Franziska Aemisegger <franziska.aemisegger[at]env.ethz.ch>
-      doi: https://doi.org/10.25326/242
-      
+      doi: https://doi.org/10.25326/242      

--- a/barbados/BCO/poldirad.yaml
+++ b/barbados/BCO/poldirad.yaml
@@ -1,0 +1,15 @@
+plugins:
+  source:
+    - module: intake_xarray
+
+sources:
+  gridded:
+    driver: zarr
+    description: Poldirad measurements on Barbados during EUREC4A - Gridded data
+    args:
+      urlpath: reference::ipfs://QmRq663s4S9pwmRpbovzZJ7dRVXyoriSdBALxo7oCxGVUG
+      consolidated: false
+    metadata:
+      doi: https://doi.org/10.25326/217
+      maintainer: Martin Hagen <martin.hagen[at]dlr.de>, Florian Ewald <florian.ewald[at]dlr.de>
+      note: This catalog entry references the original data given at the DOI but includes additional processing steps to provide a joint dataset. Please access the original dataset to check if potential issues persist.


### PR DESCRIPTION
This PR adds the gridded POLDIRAD dataset available at https://observations.ipsl.fr/aeris/eurec4a-data/BARBADOS/POLDIRAD/gridded_data/PPI_PCP_L2GRID_v1/

To easy the access to the dataset:
- 4203 files have been referenced with kerchunk
- time dimension has been added based on the filename
- variables `height`, `lat`, `lon`, `x_distance`, `y_distance` have been assumed to be constant with time

The script used for the generation of the kerchunk file is referenced in the history of the kerchunk-dataset and is available [here](https://gist.github.com/observingClouds/d134f581c16a94759abd47052cc83d2c#file-create_kerchunk_reference_poldirad_gridded-py)