### PR TITLE
Limit intake to versions < 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use you will need to install `intake`, `xarray`, `intake-xarray`, `zarr`,
 `pydap`, `requests`, `s3fs` and `ipfsspec`
 
 ```bash
-pip install intake xarray intake-xarray zarr pydap s3fs requests ipfsspec
+pip install "intake<2.0.0" xarray intake-xarray zarr pydap s3fs requests ipfsspec
 ```
 
 **Or**, if you feel courageous (and want the newest updates), you can also install the [`requirements.txt`](requirements.txt) directly:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # the most recent version of intake-xarray (v3.2.2) only supports the OPeNDAP
 # servers by URS and ESGF, the fork bellow allows for connecting to general OPeNDAP servers
-intake[dataframe] # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
+intake<2.0.0 # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
 xarray
 zarr
 fsspec>=0.7.4


### PR DESCRIPTION
With intake 2.0.0 the weekly test currently fails with:
```
("missing 'module'", {'module': 'intake_xarray'})
ERROR tests/test_catalog.py - intake.catalog.exceptions.ValidationError: Catalog '/home/runner/work/eurec4a-intake/eurec4a-intake/catalog.yml' has validation errors:
```

Intake-2 is in beta, so we should limit it to previous versions for now.