### PR TITLE
exclude newest version of netcdf4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ intake<2.0.0 # since intake 0.6.1 to_dask() doesn't work anymore without the [da
 xarray
 zarr
 fsspec>=0.7.4
-netcdf4!=1.5.4,!=1.5.5,!=1.5.5.1,!=1.6.0,!=1.6.1,!=1.6.2,!=1.6.3,!=1.6.4 # this is due to https://github.com/Unidata/netcdf4-python/issues/1052 and a CURL error in 1.6.0 (https://github.com/Unidata/netcdf-c/issues/2459) and https://github.com/eurec4a/eurec4a-intake/issues/121
+netcdf4!=1.5.4,!=1.5.5,!=1.5.5.1,!=1.6.0,!=1.6.1,!=1.6.2,!=1.6.3,!=1.6.4,!=1.6.5 # this is due to https://github.com/Unidata/netcdf4-python/issues/1052 and a CURL error in 1.6.0 (https://github.com/Unidata/netcdf-c/issues/2459) and https://github.com/eurec4a/eurec4a-intake/issues/121
 s3fs
 ipfsspec
 requests


### PR DESCRIPTION
#121 is happening again...as of this week, likely related to the release of netcdf-c 4.9.2. 
netcdf4-python v1.6.5 which has been released back in October did not cause any issues so far though.