### PR TITLE
Update BCO precipitation isotope product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add cloud droplet size distribution from specMACS instrument. By [Veronika Pörtge](https://github.com/vpoertge)
 * Add LICHT lidar data from RV Meteor as provided by the MPI-TCO catalog (#12). By [Leif Denby](https://github.com/leifdenby), [Hauke Schulz](https://github.com/observingClouds), [Tobias Kölling](https://github.com/d70-t) and [Nina Robbins](https://github.com/ninarobbins)
 ### Updated Datasets
+* Updated variable type of `flag` in precipitation isotope dataset from BCO (#164). By [Hauke Schulz](https://github.com/observingClouds)
 * Updated RV Meteor cloud radar data (LIMRAD94) to version 1.2, in which the variable hydrometeor_mask was added which tells you whether there is a signal in the processed reflectivity or not
 * Add gridded POLDIRAD product with kerchunk references to provide a continous dataset (#160). By [Hauke Schulz](https://github.com/observingClouds)
 ### Removed Datasets

--- a/barbados/BCO/bco.yaml
+++ b/barbados/BCO/bco.yaml
@@ -94,7 +94,7 @@ sources:
     description: Calibrated stable water isotope data in precipitation from the BCO during EUREC4A
     driver: netcdf
     args:
-      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/BARBADOS/BCO/precipitation/EUREC4A_BCO_stable_water_isotopes_precipitation.nc
+      urlpath: simplecache::https://observations.ipsl.fr/aeris/eurec4a-data/BARBADOS/BCO/precipitation/EUREC4A_BCO_stable_water_isotopes_precipitation_V2.0.nc
       chunks: null
     metadata:
       maintainer: Leonie Villiger <leonie.villiger[at]env.ethz.ch>, Franziska Aemisegger <franziska.aemisegger[at]env.ethz.ch>


### PR DESCRIPTION
- `flag` variable has been changed from `long` to `short` to support openDAP protocol
- fix for weekly test as old file is deleted