### PR TITLE
replace outdated miniconda action setting

### DIFF
--- a/.github/workflows/weekly_tests.yml
+++ b/.github/workflows/weekly_tests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements.txt
-        mamba install netCDF4
+        conda install netCDF4
     - name: Conda info
       run: conda info
     - name: Conda list

--- a/.github/workflows/weekly_tests.yml
+++ b/.github/workflows/weekly_tests.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         fetch-depth: 0  # required to analyze which files are modified in this branch
     - name: Set up conda
-    - uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: false
         python-version: "3.10"

--- a/.github/workflows/weekly_tests.yml
+++ b/.github/workflows/weekly_tests.yml
@@ -18,13 +18,11 @@ jobs:
       with:
         fetch-depth: 0  # required to analyze which files are modified in this branch
     - name: Set up conda
-      uses: conda-incubator/setup-miniconda@v2.2.0
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: false
-        channels: conda-forge
-        miniforge-variant: Mambaforge
-        activate-environment: eurec4a
         python-version: "3.10"
+        activate-environment: eurec4a
     - name: Install dependencies
       run: |
         pip install -r requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * update IPFS version in CI to 0.23.0 to improve access times and make weekly_test more reliable (#149). By [Hauke Schulz](https://github.com/observingClouds)
 * add citation recommendations (#155). By [Hauke Schulz](https://github.com/observingClouds)
 * install dependencies via python eurec4a package. By [Tobias Kölling](https://github.com/d70-t)
+* update conda environment github action in weekly test (#168). By [Hauke Schulz](https://github.com/observingClouds)
 
 ## 1.0.0
 


### PR DESCRIPTION
The weekly tests were disabled due to inactivity of the repo. I reenabled the workflow and run into the error that the conda environment was installed in a no longer supported way.

This PR updates the action so we can see [which datasets are currently unreachable/disappeared](https://github.com/eurec4a/eurec4a-intake/actions/runs/13355107684/job/37296756407) 😬 